### PR TITLE
squid:S1948 - Fields in a "Serializable" class should either be transient or serializable

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServlet.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServlet.java
@@ -30,10 +30,10 @@ public class CIServlet extends HttpServlet {
 	private static final String JENKINS_PROJECT_SETTINGS = "jenkins.admin.settingsProjectAdmin";
 	private static final String SERVER = "server";
 	private static final String PROJECT_KEY = "projectKey";
-	private final SoyTemplateRenderer soyTemplateRenderer;
-	private final AuthenticationContext authContext;
-	private final NavBuilder navBuilder;
-	private final Jenkins jenkins;
+	private final transient SoyTemplateRenderer soyTemplateRenderer;
+	private final transient AuthenticationContext authContext;
+	private final transient NavBuilder navBuilder;
+	private final transient Jenkins jenkins;
 	private final ProjectService projectService;
 
 	public CIServlet(SoyTemplateRenderer soyTemplateRenderer, AuthenticationContext authContext,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1948 - Fields in a "Serializable" class should either be transient or serializable.
This pull request removes 120 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1948
Please let me know if you have any questions.
George Kankava