### PR TITLE
Multiple code improvements - squid:S1948, squid:RedundantThrowsDeclarationCheck, squid:S1854

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServlet.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServlet.java
@@ -37,7 +37,7 @@ public class CIServlet extends HttpServlet {
 	private final transient AuthenticationContext authContext;
 	private final transient NavBuilder navBuilder;
 	private final transient Jenkins jenkins;
-	private final ProjectService projectService;
+	private final transient ProjectService projectService;
 
 	public CIServlet(SoyTemplateRenderer soyTemplateRenderer, AuthenticationContext authContext,
 			NavBuilder navBuilder, Jenkins jenkins, ProjectService projectService) {

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BaseCondition.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BaseCondition.java
@@ -16,7 +16,7 @@ public abstract class BaseCondition implements Condition {
     }
 
     @Override
-    public void init(Map<String, String> params) throws PluginParseException {
+    public void init(Map<String, String> params) {
         // Nothing to do here
     }
 

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/HookIsEnabledCondition.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/HookIsEnabledCondition.java
@@ -14,7 +14,7 @@ public class HookIsEnabledCondition extends BaseCondition {
 	}
 
 	@Override
-	public void init(Map<String, String> context) throws PluginParseException {
+	public void init(Map<String, String> context) {
 		// Nothing to do here
 	}
 

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/ManualButtonCondition.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/ManualButtonCondition.java
@@ -16,7 +16,7 @@ public class ManualButtonCondition extends BaseCondition {
 	}
 
 	@Override
-	public void init(Map<String, String> context) throws PluginParseException {
+	public void init(Map<String, String> context) {
 		// Nothing to do here
 	}
 

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
@@ -164,7 +164,7 @@ public class Job {
 	}
 	
 	public String buildUrl(Server jenkinsServer, String queryParams, String userToken) {
-		String buildUrl = "";
+		String buildUrl;
 		
 		if (userToken == null && this.token != null && !this.token.isEmpty()) {
 			if (queryParams.trim().isEmpty()) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1948 - Fields in a "Serializable" class should either be transient or serializable.
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous.
squid:S1854 - Dead stores should be removed.
This pull request removes 60 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1948
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1854
Please let me know if you have any questions.
George Kankava