### PR TITLE
Multiple code improvements - squid:S1905, squid:S1197, squid:S2864

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
@@ -70,23 +70,23 @@ public class SettingsService {
 			return null;
 		}
 		List<Job> jobsList = new ArrayList<Job>();
-		for (String key : parameterMap.keySet()) {
-			if (key.startsWith(JOB_PREFIX)) {
+		for (Map.Entry<String, Object> entry : parameterMap.entrySet()) {
+			if (entry.getKey().startsWith(JOB_PREFIX)) {
 				boolean isTag = false;
-				Object isTagObj = parameterMap.get(key.replace(JOB_PREFIX, ISTAG_PREFIX));
+				Object isTagObj = parameterMap.get(entry.getKey().replace(JOB_PREFIX, ISTAG_PREFIX));
 				if (isTagObj != null) {
 					isTag = Boolean.parseBoolean(isTagObj.toString());
 				}
 				Job job = new Job.JobBuilder(jobsList.size())
-						.jobName(parameterMap.get(key).toString()).isTag(isTag)
-						.triggers(parameterMap.get(key.replace(JOB_PREFIX, TRIGGER_PREFIX))
+						.jobName(entry.getValue().toString()).isTag(isTag)
+						.triggers(parameterMap.get(entry.getKey().replace(JOB_PREFIX, TRIGGER_PREFIX))
 								.toString().split(";"))
-						.buildParameters(parameterMap.get(key.replace(JOB_PREFIX, PARAM_PREFIX))
+						.buildParameters(parameterMap.get(entry.getKey().replace(JOB_PREFIX, PARAM_PREFIX))
 								.toString())
-						.token(parameterMap.get(key.replace(JOB_PREFIX, TOKEN_PREFIX)).toString())
-						.branchRegex(parameterMap.get(key.replace(JOB_PREFIX, BRANCH_PREFIX))
+						.token(parameterMap.get(entry.getKey().replace(JOB_PREFIX, TOKEN_PREFIX)).toString())
+						.branchRegex(parameterMap.get(entry.getKey().replace(JOB_PREFIX, BRANCH_PREFIX))
 								.toString())
-						.pathRegex(parameterMap.get(key.replace(JOB_PREFIX, PATH_PREFIX))
+						.pathRegex(parameterMap.get(entry.getKey().replace(JOB_PREFIX, PATH_PREFIX))
 								.toString())
 						.createJob();
 

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
@@ -107,7 +107,7 @@ public class Job {
 		public JobBuilder buildParameters(String parameterString) {
 			Map<String, String> parameterMap = new LinkedHashMap<String, String>();
 			if (!parameterString.isEmpty()) {
-				String lines[] = parameterString.split("\\r?\\n");
+				String[] lines = parameterString.split("\\r?\\n");
 				for (String line : lines) {
 					String[] pair = line.split("=");
 					String key = pair[0];
@@ -139,7 +139,7 @@ public class Job {
 		String queryParams = "";
 		Iterator<Entry<String, String>> it = buildParameters.entrySet().iterator();
 		while (it.hasNext()) {
-			Map.Entry<String, String> pair = (Map.Entry<String, String>) it.next();
+			Map.Entry<String, String> pair = it.next();
 			queryParams += pair.getKey() + "=" + pair.getValue().split(";")[0]
 					+ (it.hasNext() ? "&" : "");
 			it.remove();

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
@@ -121,7 +121,7 @@ public class BuildResource extends RestResource {
 		String queryParams = "";
 		Iterator<Entry<String, List<String>>> it = queryParameters.entrySet().iterator();
 		while (it.hasNext()) {
-			Map.Entry<String, List<String>> pair = (Map.Entry<String, List<String>>) it.next();
+			Map.Entry<String, List<String>> pair = it.next();
 			queryParams += pair.getKey() + "=" + pair.getValue().get(0) + (it.hasNext() ? "&" : "");
 			it.remove();
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1905 - Redundant casts should not be used.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
This pull request removes 20 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
George Kankava