### PR TITLE
Fixed 411 no length specified error

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
@@ -281,6 +281,8 @@ public class Jenkins {
 
 			connection.setReadTimeout(45000);
 			connection.setInstanceFollowRedirects(true);
+			connection.setDoOutput(true);
+			connection.setFixedLengthStreamingMode(0);
 			HttpURLConnection.setFollowRedirects(true);
 
 			connection.connect();


### PR DESCRIPTION
We installed the plugin and pointed it to our Jenkins instance, but it kept erroring out with

> c.k.s.p.ciserver.Jenkins Exception for parametized build: Length Required

Adding these couple lines fixed it.