### PR TITLE
squid:S1166 - Exception handlers should preserve the original exception

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
@@ -309,9 +309,11 @@ public class Jenkins {
 			return jenkinsMessage.error(true).messageText("Malformed URL:" + e.getMessage())
 					.build();
 		} catch (IOException e) {
+			logger.error("IOException in Jenkins.httpPost: " + e.getMessage(), e);
 			return jenkinsMessage.error(true).messageText("IO exception occurred" + e.getMessage())
 					.build();
 		} catch (Exception e) {
+			logger.error("Exception in Jenkins.httpPost: " + e.getMessage(), e);
 			return jenkinsMessage.error(true).messageText("Something went wrong: " + e.getMessage())
 					.build();
 		}

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
@@ -12,8 +12,11 @@ import com.atlassian.bitbucket.setting.Settings;
 import com.atlassian.bitbucket.user.SecurityService;
 import com.atlassian.bitbucket.util.Operation;
 import com.kylenicholls.stash.parameterizedbuilds.item.Job;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SettingsService {
+	private static final Logger logger = LoggerFactory.getLogger(SettingsService.class);
 	private static final String KEY = "com.kylenicholls.stash.parameterized-builds:parameterized-build-hook";
 	public static final String JOB_PREFIX = "jobName-";
 	public static final String ISTAG_PREFIX = "isTag-";
@@ -43,6 +46,7 @@ public class SettingsService {
 						}
 					});
 		} catch (Exception e) {
+			logger.error("Exception in SettingsService.getSettings: " + e.getMessage(), e);
 			return null;
 		}
 
@@ -60,6 +64,7 @@ public class SettingsService {
 						}
 					});
 		} catch (Exception e1) {
+			logger.error("Exception in SettingsService.getHook: " + e1.getMessage(), e1);
 			return null;
 		}
 		return hook;

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
@@ -1,5 +1,8 @@
 package com.kylenicholls.stash.parameterizedbuilds.item;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -12,6 +15,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriBuilder;
 
 public class Job {
+	private static final Logger logger = LoggerFactory.getLogger(Job.class);
 	private final int jobId;
 	private final String jobName;
 	private final boolean isTag;
@@ -114,6 +118,7 @@ public class Job {
 				try {
 					triggers.add(Trigger.valueOf(trig.toUpperCase()));
 				} catch (IllegalArgumentException e) {
+					logger.error("IllegalArgumentException in Job.triggers: " + e.getMessage(), e);
 					triggers.add(Trigger.NULL);
 				}
 			}


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1166 - Exception handlers should preserve the original exception.
This pull request removes 50 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1166
Please let me know if you have any questions.
George Kankava