### PR TITLE
squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
@@ -114,6 +114,7 @@ public class ParameterizedBuildHook
 					ChangesRequest request = new ChangesRequest.Builder(repository,
 							refChange.getToHash()).sinceId(refChange.getFromHash()).build();
 					commitService.streamChanges(request, new AbstractChangeCallback() {
+						@Override
 						public boolean onChange(Change change) throws IOException {
 							if (change.getPath().toString().matches(pathRegex)) {
 								jenkins.triggerJob(buildUrl, token, prompt);
@@ -122,10 +123,12 @@ public class ParameterizedBuildHook
 							return true;
 						}
 
+						@Override
 						public void onStart(ChangeContext context) throws IOException {
 							// noop
 						}
 
+						@Override
 						public void onEnd(ChangeSummary summary) throws IOException {
 							// noop
 						}

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHook.java
@@ -123,6 +123,7 @@ public class PullRequestHook {
 					pullRequestService
 							.streamChanges(new PullRequestChangesRequest.Builder(pullRequest)
 									.build(), new AbstractChangeCallback() {
+										@Override
 										public boolean onChange(Change change) throws IOException {
 											String changedFile = change.getPath().toString();
 											if (changedFile.matches(pathRegex)) {
@@ -132,11 +133,13 @@ public class PullRequestHook {
 											return true;
 										}
 
+										@Override
 										public void onEnd(ChangeSummary summary)
 												throws IOException {
 											// noop
 										}
 
+										@Override
 										public void onStart(ChangeContext context)
 												throws IOException {
 											// noop

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BaseCondition.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BaseCondition.java
@@ -19,6 +19,7 @@ public abstract class BaseCondition implements Condition {
 		// Nothing to do here
 	}
 
+	@Override
 	public abstract boolean shouldDisplay(Map<String, Object> context);
 
 	protected Repository getRepository(Map<String, Object> context) {


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one.
This pull request removes 35 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1161
Please let me know if you have any questions.
George Kankava