### PR TITLE
squid:S1132 - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServlet.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServlet.java
@@ -105,7 +105,7 @@ public class CIServlet extends HttpServlet {
 			} else {
 				Server server = getServerFromMap(req);
 				boolean clearSettings = req.getParameter("clear-settings") != null
-						&& req.getParameter("clear-settings").equals("on") ? true : false;
+						&& "on".equals(req.getParameter("clear-settings")) ? true : false;
 				if (pathInfo.contains("/jenkins/project/")) {
 					String projectKey = pathInfo.replaceAll(".*/jenkins/project/", "")
 							.split("/")[0];
@@ -132,7 +132,7 @@ public class CIServlet extends HttpServlet {
 
 	private Server getServerFromMap(HttpServletRequest req) {
 		boolean jenkinsAltUrl = req.getParameter("jenkinsAltUrl") != null
-				&& req.getParameter("jenkinsAltUrl").equals("on") ? true : false;
+				&& "on".equals(req.getParameter("jenkinsAltUrl")) ? true : false;
 		return new Server(req.getParameter("jenkinsUrl"), req.getParameter("jenkinsUser"),
 				req.getParameter("jenkinsToken"), jenkinsAltUrl);
 	}

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
@@ -115,7 +115,7 @@ public class Jenkins {
 			}
 			// legacy settings
 			String[] serverProps = settingObj.toString().split(";");
-			boolean altUrl = serverProps.length > 3 && serverProps[3].equals("true") ? true : false;
+			boolean altUrl = serverProps.length > 3 && "true".equals(serverProps[3]) ? true : false;
 			return new Server(serverProps[0], serverProps[1], serverProps[2], altUrl);
 		}
 		return null;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1132 - Strings literals should be placed on the left side when checking for equality.
This pull request removes 30 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1132
Please let me know if you have any questions.
George Kankava