### PR TITLE
squid:S1168 - Empty arrays and collections should be returned instead of null

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
@@ -1,6 +1,7 @@
 package com.kylenicholls.stash.parameterizedbuilds.helper;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -72,7 +73,7 @@ public class SettingsService {
 
 	public List<Job> getJobs(final Map<String, Object> parameterMap) {
 		if (parameterMap.keySet().isEmpty()) {
-			return null;
+			return Collections.emptyList();
 		}
 		List<Job> jobsList = new ArrayList<>();
 		for (Map.Entry<String, Object> entry : parameterMap.entrySet()) {

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsServiceTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -74,7 +75,7 @@ public class SettingsServiceTest {
 		Map<String, Object> jobConfig = new HashMap<>();
 		List<Job> jobs = settingsService.getJobs(jobConfig);
 
-		assertEquals(null, jobs);
+		assertEquals(Collections.emptyList(), jobs);
 	}
 
 	@Test


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1168 - Empty arrays and collections should be returned instead of null.
This pull request removes 30 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1168
Please let me know if you have any questions.
George Kankava