### PR TITLE
squid:S3038 - Abstract methods should not be redundant

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BaseCondition.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BaseCondition.java
@@ -19,9 +19,6 @@ public abstract class BaseCondition implements Condition {
 		// Nothing to do here
 	}
 
-	@Override
-	public abstract boolean shouldDisplay(Map<String, Object> context);
-
 	protected Repository getRepository(Map<String, Object> context) {
 		final Object obj = context.get(REPOSITORY);
 		// Get current repo, if failure disable button


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S3038 - Abstract methods should not be redundant.
This pull request removes 2 minutes of technical debt.
Please let me know if you have any questions.
George Kankava