### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
@@ -180,8 +180,7 @@ public class Job {
 			return null;
 		}
 
-		UriBuilder builder = setUrlPath(jenkinsServer, useUserToken, this.buildParameters
-				.size() != 0);
+		UriBuilder builder = setUrlPath(jenkinsServer, useUserToken, !this.buildParameters.isEmpty());
 
 		for (Entry<String, Object> param : this.buildParameters) {
 			String key = param.getKey();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
This pull request removes 2 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava