### PR TITLE
Created hook enabled check for pull requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>2.6.5</version>
+	<version>2.6.6</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHook.java
@@ -78,6 +78,9 @@ public class PullRequestHook {
 
 	private void triggerFromPR(PullRequest pullRequest, Trigger trigger) throws IOException {
 		Repository repository = pullRequest.getFromRef().getRepository();
+		if (!settingsService.getHook(repository).isEnabled()) {
+			return;
+		}
 		ApplicationUser user = pullRequest.getAuthor().getUser();
 		String projectKey = repository.getProject().getKey();
 		String branch = pullRequest.getFromRef().getDisplayId();


### PR DESCRIPTION
Solves issue #56. However, I'm not convinced this is the best solution. I tried to look into something along the lines of [this](https://developer.atlassian.com/bitbucket/server/docs/latest/how-tos/responding-to-application-events.html) or [this](https://developer.atlassian.com/confdev/confluence-plugin-guide/writing-confluence-plugins/making-your-plugin-modules-state-aware). However, I was not able to make either of these work. Maybe someone else can manage it.