### PR TITLE
Added support for Jenkins CSRF protection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>2.6.7</version>
+	<version>2.6.8</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>


### PR DESCRIPTION
As mentioned in both [Issue-67](https://github.com/KyleLNicholls/parameterized-builds/issues/67) and [Issue-65](https://github.com/KyleLNicholls/parameterized-builds/issues/65), a Jenkins instance with CSRF protection can not be triggered. Instead, the request will return with a 403 status code. This branch solves the issue by always trying to retrieve a crumb from the Jenkins instance and adding the appropriate header if a crumb is returned.

This creates a side effect where a Jenkins instance without CSRF protection will be queried for the crumb which will return a 404. In this case, no crumb header is added to the original request. An alternative to this approach, a checkbox could be added to the jenkins settings to indicate if CSRF protection is set on the jenkins instances and only retrieve the crumb if so.

I have not done extensive testing on this branch. I have verified that a Jenkins instance with and without CSRF protection can trigger a job but I have not tested with various security types in Jenkins (only tested when security realm was set to Jenkins’ own user database). In addition, I have not added any unit tests.