### PR TITLE
Created permissions check for manual trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ they will be triggered in the order they are added.
 * [Build Parameters](#build-parameters)
 * `Ref Filter` uses java regex syntax to only trigger a 
 build for branches/tags that match the filter
- * the filter will only be used for branch/tag creation, branch pushes, and branch/tag deletion
- * leave blank to match all branches
+  * the filter will only be used for branch/tag creation, branch pushes, and branch/tag deletion
+  * leave blank to match all branches
 * `Monitored Paths` will only trigger a build if a file in the diff matches the filter
- * the filter will only be used for branch pushes and PR events
- * leave blank to match all changes
+  * the filter will only be used for branch pushes and PR events
+  * leave blank to match all changes
+* `Required Build Permission` will restrict who can trigger a Jenkins job using the repository permissions
+  * This is only available on manual triggers
 
 #### Link your bitbucket server account to Jenkins
 ![Jenkins user settings](readme/img/jenkins_user.png)  

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>3.0.1</version>
+	<version>3.1.0</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>
@@ -135,6 +135,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.atlassian.plugin</groupId>
+			<artifactId>atlassian-spring-scanner-annotation</artifactId>
+			<version>${atlassian.spring.scanner.version}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.10</version>
@@ -236,11 +242,34 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>com.atlassian.plugin</groupId>
+				<artifactId>atlassian-spring-scanner-maven-plugin</artifactId>
+				<version>${atlassian.spring.scanner.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>atlassian-spring-scanner</goal>
+						</goals>
+						<phase>process-classes</phase>
+					</execution>
+				</executions>
+				<configuration>
+					<scannedDependencies>
+						<dependency>
+							<groupId>com.atlassian.plugin</groupId>
+							<artifactId>atlassian-spring-scanner-external-jar</artifactId>
+						</dependency>
+					</scannedDependencies>
+					<verbose>false</verbose>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<properties>
 		<bitbucket.server.version>5.1.0</bitbucket.server.version>
 		<bitbucket.data.version>5.1.0</bitbucket.data.version>
+		<atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
 		<amps.version>6.1.0</amps.version>
 		<plugin.testrunner.version>1.2.0</plugin.testrunner.version>
 	</properties>

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BuildPermissionsCondition.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BuildPermissionsCondition.java
@@ -1,0 +1,54 @@
+package com.kylenicholls.stash.parameterizedbuilds.conditions;
+
+import com.atlassian.bitbucket.auth.AuthenticationContext;
+import com.atlassian.bitbucket.permission.Permission;
+import com.atlassian.bitbucket.permission.PermissionService;
+import com.atlassian.bitbucket.repository.Repository;
+import com.atlassian.bitbucket.setting.Settings;
+import com.atlassian.bitbucket.user.ApplicationUser;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import com.kylenicholls.stash.parameterizedbuilds.helper.SettingsService;
+import com.kylenicholls.stash.parameterizedbuilds.item.Job;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Map;
+
+public class BuildPermissionsCondition extends BaseCondition{
+
+    private final PermissionService permissionService;
+    private final AuthenticationContext authContext;
+
+    @Autowired
+    public BuildPermissionsCondition(@ComponentImport PermissionService permissionService, SettingsService service, AuthenticationContext authContext) {
+        super(service);
+        this.permissionService = permissionService;
+        this.authContext = authContext;
+    }
+
+    public boolean checkPermissions(Job job, Repository repository, ApplicationUser user){
+        try {
+            Permission permissionRequired = Permission.valueOf(job.getPermissions());
+            return this.permissionService.hasRepositoryPermission(user, repository, permissionRequired);
+        } catch (IllegalArgumentException ex) {
+            return true;
+        }
+    }
+
+    @Override
+    public boolean shouldDisplay(Map<String, Object> context) {
+        final Repository repository = getRepository(context);
+        if (repository == null) {
+            return false;
+        }
+        Settings settings = settingsService.getSettings(repository);
+        ApplicationUser user = authContext.getCurrentUser();
+
+        for (Job job : settingsService.getJobs(settings.asMap())) {
+            if (checkPermissions(job, repository, user)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BuildPermissionsCondition.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BuildPermissionsCondition.java
@@ -26,12 +26,8 @@ public class BuildPermissionsCondition extends BaseCondition{
     }
 
     public boolean checkPermissions(Job job, Repository repository, ApplicationUser user){
-        try {
-            Permission permissionRequired = Permission.valueOf(job.getPermissions());
-            return this.permissionService.hasRepositoryPermission(user, repository, permissionRequired);
-        } catch (IllegalArgumentException ex) {
-            return true;
-        }
+        Permission permissionRequired = Permission.valueOf(job.getPermissions());
+        return this.permissionService.hasRepositoryPermission(user, repository, permissionRequired);
     }
 
     @Override

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
@@ -94,7 +94,7 @@ public class SettingsService {
 						.pathRegex(parameterMap.get(entry.getKey().replace(JOB_PREFIX, PATH_PREFIX))
 								.toString())
 						.permissions(fetchValue(entry.getKey().replace(JOB_PREFIX, PERMISSIONS_PREFIX),
-								parameterMap, "LICENSED_USER"))
+								parameterMap, "REPO_READ"))
 						.build();
 
 				jobsList.add(job);

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
@@ -26,6 +26,7 @@ public class SettingsService {
 	public static final String PARAM_PREFIX = "buildParameters-";
 	public static final String BRANCH_PREFIX = "branchRegex-";
 	public static final String PATH_PREFIX = "pathRegex-";
+	public static final String PERMISSIONS_PREFIX = "requirePermission-";
 
 	private RepositoryHookService hookService;
 	private SecurityService securityService;
@@ -78,14 +79,9 @@ public class SettingsService {
 		List<Job> jobsList = new ArrayList<>();
 		for (Map.Entry<String, Object> entry : parameterMap.entrySet()) {
 			if (entry.getKey().startsWith(JOB_PREFIX)) {
-				boolean isTag = false;
-				Object isTagObj = parameterMap
-						.get(entry.getKey().replace(JOB_PREFIX, ISTAG_PREFIX));
-				if (isTagObj != null) {
-					isTag = Boolean.parseBoolean(isTagObj.toString());
-				}
 				Job job = new Job.JobBuilder(jobsList.size()).jobName(entry.getValue().toString())
-						.isTag(isTag)
+						.isTag(fetchValue(entry.getKey().replace(JOB_PREFIX, ISTAG_PREFIX),
+								parameterMap, false))
 						.triggers(parameterMap
 								.get(entry.getKey().replace(JOB_PREFIX, TRIGGER_PREFIX)).toString()
 								.split(";"))
@@ -97,11 +93,31 @@ public class SettingsService {
 								.get(entry.getKey().replace(JOB_PREFIX, BRANCH_PREFIX)).toString())
 						.pathRegex(parameterMap.get(entry.getKey().replace(JOB_PREFIX, PATH_PREFIX))
 								.toString())
+						.permissions(fetchValue(entry.getKey().replace(JOB_PREFIX, PERMISSIONS_PREFIX),
+								parameterMap, "LICENSED_USER"))
 						.build();
 
 				jobsList.add(job);
 			}
 		}
 		return jobsList;
+	}
+
+	public boolean fetchValue(String attr, Map parameterMap, boolean defaultVal){
+		boolean val = defaultVal;
+		Object fetchedVal = parameterMap.get(attr);
+		if (fetchedVal != null) {
+			val = Boolean.parseBoolean(fetchedVal.toString());
+		}
+		return val;
+	}
+
+	public String fetchValue(String attr, Map parameterMap, String defaultVal){
+		String val = defaultVal;
+		Object fetchedVal = parameterMap.get(attr);
+		if (fetchedVal != null) {
+			val = fetchedVal.toString();
+		}
+		return val;
 	}
 }

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
@@ -26,6 +26,7 @@ public class Job {
 	private final List<Entry<String, Object>> buildParameters;
 	private final String branchRegex;
 	private final String pathRegex;
+	private final String permissions;
 
 	private Job(JobBuilder builder) {
 		this.jobId = builder.jobId;
@@ -36,6 +37,7 @@ public class Job {
 		this.buildParameters = builder.buildParameters;
 		this.branchRegex = builder.branchRegex;
 		this.pathRegex = builder.pathRegex;
+		this.permissions = builder.permissions;
 	}
 
 	public int getJobId() {
@@ -70,6 +72,10 @@ public class Job {
 		return pathRegex;
 	}
 
+	public String getPermissions() {
+		return permissions;
+	}
+
 	public Map<String, Object> asMap(BitbucketVariables bitbucketVariables) {
 		Map<String, Object> map = new LinkedHashMap<>();
 		map.put("id", jobId);
@@ -99,6 +105,7 @@ public class Job {
 		private List<Entry<String, Object>> buildParameters;
 		private String branchRegex;
 		private String pathRegex;
+		private String permissions;
 
 		public JobBuilder(int jobId) {
 			this.jobId = jobId;
@@ -168,6 +175,11 @@ public class Job {
 
 		public JobBuilder pathRegex(String pathRegex) {
 			this.pathRegex = pathRegex;
+			return this;
+		}
+
+		public JobBuilder permissions(String permissions) {
+			this.permissions = permissions;
 			return this;
 		}
 

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -22,6 +22,7 @@
   <component key="ParameterizedBuildHook" class="com.kylenicholls.stash.parameterizedbuilds.ParameterizedBuildHook"/>
   <component key="PullRequestHook" class="com.kylenicholls.stash.parameterizedbuilds.PullRequestHook"/>
   <component key="Jenkins" class="com.kylenicholls.stash.parameterizedbuilds.ciserver.Jenkins"/>
+  <component key="PermissionsCondition" class="com.kylenicholls.stash.parameterizedbuilds.conditions.BuildPermissionsCondition"/>
   
   <!-- add our web resources -->
   <web-resource key="parameterized-builds-resources" name="Parameterized Builds Web Resources">
@@ -120,6 +121,7 @@
     <conditions type="AND">
       <condition class="com.kylenicholls.stash.parameterizedbuilds.conditions.HookIsEnabledCondition"/>
       <condition class="com.kylenicholls.stash.parameterizedbuilds.conditions.ManualButtonCondition"/>
+      <condition class="com.kylenicholls.stash.parameterizedbuilds.conditions.BuildPermissionsCondition"/>
     </conditions>
   </client-web-item>
   <client-web-item key="blist-trigger-jenkins" name="Trigger Jenkins Builds From Branch List" section="bitbucket.branch.list.actions.dropdown" weight="1000">
@@ -130,6 +132,7 @@
     <conditions type="AND">
       <condition class="com.kylenicholls.stash.parameterizedbuilds.conditions.HookIsEnabledCondition"/>
       <condition class="com.kylenicholls.stash.parameterizedbuilds.conditions.ManualButtonCondition"/>
+      <condition class="com.kylenicholls.stash.parameterizedbuilds.conditions.BuildPermissionsCondition"/>
     </conditions>
   </client-web-item>
   

--- a/src/main/resources/less/hooks.less
+++ b/src/main/resources/less/hooks.less
@@ -23,3 +23,7 @@
 .hide-paths {
     display:none;
 }
+
+.hide-permissions {
+    display:none;
+}

--- a/src/main/resources/static/parameterized-build-hook.js
+++ b/src/main/resources/static/parameterized-build-hook.js
@@ -45,6 +45,7 @@
                 'branch' : '',
                 'path' : '',
                 'param' : '',
+                'permissions' : '',
                 'collapsed' : false
             });
             $(html).insertBefore($(this));
@@ -113,6 +114,10 @@
                 		$(currentField).find('label').attr('for', 'pathRegex-' + index);
                 		$(currentField).find('input').attr('id', 'pathRegex-' + index).attr('name', 'pathRegex-' + index);
                 	}
+                	if (index2 === 8) {
+                        $(currentField).find('label').attr('for', 'requirePermission-' + index);
+                        $(currentField).find('select').attr('id', 'requirePermission-' + index).attr('name', 'requirePermission-' + index);
+                    }
             	});
             });
         });
@@ -160,10 +165,13 @@
         $(document).on('click', '.manual', function(e) {
             e.preventDefault();
             var classes = $(this).find('span').attr('class');
+            var id = $(this).parent().parent().get(0).id.replace("job-", "");
             if (classes.indexOf("aui-lozenge-success") > -1) {
             	updateTrigger($(this).parent().parent(), "manual;", false);
+                $(this).parent().parent().find('#requirePermission-' + id).parent().addClass('hide-permissions');
             } else {
             	updateTrigger($(this).parent().parent(), "manual;", true);
+            	$(this).parent().parent().find('#requirePermission-' + id).parent().removeClass('hide-permissions');
             }
             $(this).find('span').toggleClass("aui-lozenge-success");
         });

--- a/src/main/resources/static/parameterized-build-hook.soy
+++ b/src/main/resources/static/parameterized-build-hook.soy
@@ -10,7 +10,7 @@
 				<div class="field-group"><div class="error">{$errors['jenkins-admin-error']}</div></div>
 		{/if}
 		{let $configKeys: $config ? keys($config) : [] /}
-		{let $visibleInputsCount: $configKeys.length > 0 ? ($configKeys.length / 7) : 1 /}
+		{let $visibleInputsCount: $configKeys.length > 0 ? ($configKeys.length / 8) : 1 /}
 		{for $i in range($visibleInputsCount)}
 			{call .addJob}
 				{param canDelete: $visibleInputsCount > 1 /}
@@ -22,6 +22,7 @@
 				{param buildParameters: $config and $config['buildParameters-' + $i] ? $config['buildParameters-' + $i] : null /}
 				{param branchRegex: $config and $config['branchRegex-' + $i] ? $config['branchRegex-' + $i] : null /}
 				{param pathRegex: $config and $config['pathRegex-' + $i] ? $config['pathRegex-' + $i] : null /}
+				{param requirePermission: $config and $config['requirePermission-' + $i] ? $config['requirePermission-' + $i] : null /}
               	{param errors: $errors ? $errors : null /}
               	{param collapsed: not $errors and $configKeys.length > 0 /}
 			{/call}
@@ -46,6 +47,7 @@
  * @param buildParameters
  * @param branchRegex
  * @param pathRegex
+ * @param requirePermission
  * @param errors
  * @param collapsed
  */
@@ -168,6 +170,35 @@
         	Supported triggers: AUTO MERGE, PUSH EVENT, PR OPENED, PR MERGED, PR DECLINED' /}
         	{param extraClasses: $pathClasses /}
 	    {/call}
+	    {let $permissionsClasses}
+        	{if $collapsed and not strContains($triggers, 'manual;')}
+        		hidden hide-permissions
+        	{elseif $collapsed and  strContains($triggers, 'manual;')}
+        		hidden
+        	{elseif not $collapsed and not  strContains($triggers, 'manual;')}
+        		hide-permissions
+        	{/if}
+        {/let}
+	    {call aui.form.selectField}
+        	{param id: 'requirePermission-' + $count /}
+        	{param value: $requirePermission /}
+        	{param labelContent: 'Required Build Permission' /}
+            {param options: [[
+                    'text': 'Any',
+                    'value': 'LICENSED_USER'
+                ],[
+                    'text': 'Read',
+                    'value': 'REPO_READ'
+                ],[
+                    'text': 'Write',
+                    'value': 'REPO_WRITE'
+                ],[
+                    'text': 'Admin',
+                    'value': 'REPO_ADMIN'
+                ]] /}
+        	{param descriptionText: 'Only allow users with the given repository permission or higher to trigger this job.' /}
+            {param extraClasses: $permissionsClasses /}
+        {/call}
 		<hr>
     </div>
 {/template}

--- a/src/main/resources/static/parameterized-build-hook.soy
+++ b/src/main/resources/static/parameterized-build-hook.soy
@@ -184,9 +184,6 @@
         	{param value: $requirePermission /}
         	{param labelContent: 'Required Build Permission' /}
             {param options: [[
-                    'text': 'Any',
-                    'value': 'LICENSED_USER'
-                ],[
                     'text': 'Read',
                     'value': 'REPO_READ'
                 ],[

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BuildPermissionsConditionTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BuildPermissionsConditionTest.java
@@ -1,0 +1,99 @@
+package com.kylenicholls.stash.parameterizedbuilds.conditions;
+
+import com.atlassian.bitbucket.auth.AuthenticationContext;
+import com.atlassian.bitbucket.permission.*;
+import com.atlassian.bitbucket.repository.Repository;
+import com.atlassian.bitbucket.setting.Settings;
+import com.kylenicholls.stash.parameterizedbuilds.helper.SettingsService;
+import com.kylenicholls.stash.parameterizedbuilds.item.Job;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BuildPermissionsConditionTest {
+
+    private BuildPermissionsCondition condition;
+    private Repository repository;
+    private Map<String, Object> context;
+    private SettingsService settingsService;
+    private Settings settings;
+
+    @Before
+    public void setup() {
+        repository = mock(Repository.class);
+        settingsService = mock(SettingsService.class);
+        settings = mock(Settings.class);
+
+        context = new HashMap<>();
+        context.put("repository", repository);
+
+        PermissionService permissionService = mock(PermissionService.class);
+        AuthenticationContext authContext = mock(AuthenticationContext.class);
+        condition = new BuildPermissionsCondition(permissionService, settingsService, authContext);
+
+        when(permissionService.hasRepositoryPermission(any(), any(), eq(Permission.REPO_WRITE))).thenReturn(true);
+        when(permissionService.hasRepositoryPermission(any(), any(), eq(Permission.REPO_READ))).thenReturn(true);
+    }
+
+    @Test
+    public void testShouldNotDisplayIfRepositoryNull() {
+        context.put("repository", null);
+        assertFalse(condition.shouldDisplay(context));
+    }
+
+    @Test
+    public void testShouldNotDisplayIfNotRepository() {
+        context.put("repository", "notARepository");
+        assertFalse(condition.shouldDisplay(context));
+    }
+
+    @Test
+    public void testShouldNotDisplayIfInsufficientPermissions() {
+        when(settingsService.getSettings(repository)).thenReturn(settings);
+        Job job = new Job.JobBuilder(1).permissions("REPO_ADMIN").build();
+        List<Job> jobs = new ArrayList<>();
+        jobs.add(job);
+        when(settingsService.getJobs(any())).thenReturn(jobs);
+        assertFalse(condition.shouldDisplay(context));
+    }
+
+    @Test
+    public void testShouldDisplayExplicitPermissionPresent() {
+        when(settingsService.getSettings(repository)).thenReturn(settings);
+        Job job = new Job.JobBuilder(1).permissions("REPO_WRITE").build();
+        List<Job> jobs = new ArrayList<>();
+        jobs.add(job);
+        when(settingsService.getJobs(any())).thenReturn(jobs);
+        assertTrue(condition.shouldDisplay(context));
+    }
+
+    @Test
+    public void testShouldDisplayImplicitPermissionPresent() {
+        when(settingsService.getSettings(repository)).thenReturn(settings);
+        Job job = new Job.JobBuilder(1).permissions("REPO_READ").build();
+        List<Job> jobs = new ArrayList<>();
+        jobs.add(job);
+        when(settingsService.getJobs(any())).thenReturn(jobs);
+        assertTrue(condition.shouldDisplay(context));
+    }
+
+    @Test
+    public void testShouldDisplayBadPermission() {
+        when(settingsService.getSettings(repository)).thenReturn(settings);
+        Job job = new Job.JobBuilder(1).permissions("None").build();
+        List<Job> jobs = new ArrayList<>();
+        jobs.add(job);
+        when(settingsService.getJobs(any())).thenReturn(jobs);
+        assertTrue(condition.shouldDisplay(context));
+    }
+}

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BuildPermissionsConditionTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/conditions/BuildPermissionsConditionTest.java
@@ -87,13 +87,4 @@ public class BuildPermissionsConditionTest {
         assertTrue(condition.shouldDisplay(context));
     }
 
-    @Test
-    public void testShouldDisplayBadPermission() {
-        when(settingsService.getSettings(repository)).thenReturn(settings);
-        Job job = new Job.JobBuilder(1).permissions("None").build();
-        List<Job> jobs = new ArrayList<>();
-        jobs.add(job);
-        when(settingsService.getJobs(any())).thenReturn(jobs);
-        assertTrue(condition.shouldDisplay(context));
-    }
 }

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsServiceTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsServiceTest.java
@@ -41,6 +41,7 @@ public class SettingsServiceTest {
 		String token = "token";
 		String branchRegex = "branchRegex";
 		String pathRegex = "pathRegex";
+		String permissions = "permissions";
 		Map<String, Object> jobConfig = new LinkedHashMap<>();
 		jobConfig.put(SettingsService.JOB_PREFIX + "0", jobName);
 		jobConfig.put(SettingsService.TRIGGER_PREFIX + "0", triggers);
@@ -48,12 +49,14 @@ public class SettingsServiceTest {
 		jobConfig.put(SettingsService.TOKEN_PREFIX + "0", token);
 		jobConfig.put(SettingsService.BRANCH_PREFIX + "0", branchRegex);
 		jobConfig.put(SettingsService.PATH_PREFIX + "0", pathRegex);
+		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "0", permissions);
 		jobConfig.put(SettingsService.JOB_PREFIX + "1", jobName2);
-		jobConfig.put(SettingsService.TRIGGER_PREFIX + "1", "");
+		jobConfig.put(SettingsService.TRIGGER_PREFIX + "1", "add");
 		jobConfig.put(SettingsService.PARAM_PREFIX + "1", "");
 		jobConfig.put(SettingsService.TOKEN_PREFIX + "1", "");
 		jobConfig.put(SettingsService.BRANCH_PREFIX + "1", "");
 		jobConfig.put(SettingsService.PATH_PREFIX + "1", "");
+		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "1", "");
 		List<Job> jobs = settingsService.getJobs(jobConfig);
 
 		List<Trigger> triggerList = Arrays.asList(Trigger.ADD, Trigger.PUSH);
@@ -82,11 +85,12 @@ public class SettingsServiceTest {
 	public void testGetJobWithUndefinedRefType() {
 		Map<String, Object> jobConfig = new HashMap<>();
 		jobConfig.put(SettingsService.JOB_PREFIX + "0", "jobname");
-		jobConfig.put(SettingsService.TRIGGER_PREFIX + "0", "");
+		jobConfig.put(SettingsService.TRIGGER_PREFIX + "0", "add");
 		jobConfig.put(SettingsService.PARAM_PREFIX + "0", "");
 		jobConfig.put(SettingsService.TOKEN_PREFIX + "0", "");
 		jobConfig.put(SettingsService.BRANCH_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PATH_PREFIX + "0", "");
+		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "0", "");
 		List<Job> jobs = settingsService.getJobs(jobConfig);
 
 		assertFalse(jobs.get(0).getIsTag());
@@ -97,11 +101,12 @@ public class SettingsServiceTest {
 		Map<String, Object> jobConfig = new HashMap<>();
 		jobConfig.put(SettingsService.JOB_PREFIX + "0", "jobname");
 		jobConfig.put(SettingsService.ISTAG_PREFIX + "0", "true");
-		jobConfig.put(SettingsService.TRIGGER_PREFIX + "0", "");
+		jobConfig.put(SettingsService.TRIGGER_PREFIX + "0", "add");
 		jobConfig.put(SettingsService.PARAM_PREFIX + "0", "");
 		jobConfig.put(SettingsService.TOKEN_PREFIX + "0", "");
 		jobConfig.put(SettingsService.BRANCH_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PATH_PREFIX + "0", "");
+		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "0", "");
 		List<Job> jobs = settingsService.getJobs(jobConfig);
 
 		assertTrue(jobs.get(0).getIsTag());


### PR DESCRIPTION
As suggested by ISSUE #51, permissions can be set to restrict certain users from triggering build. This uses the Bitbucket repository permissions to determine if a user can use a trigger.

I've tested this rather extensively. There is a slight bug when downgrading from a version with this feature to a previous one without manual trigger permissions where a null job is created. Since this requires downgrading and the null job doesn't seem to have any real effect, I don't consider it worth addressing.