### PR TITLE
Add choice params fix to pr requests page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>2.6.8</version>
+	<version>2.6.9</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>

--- a/src/main/resources/scripts/jenkins/pb-pr-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-pr-trigger.js
@@ -107,30 +107,32 @@ define('jenkins/parameterized-build-pullrequest', [
 				var keyValue = parameters[i];
 				for (var key in keyValue){
 					var value = keyValue[key];
-					if (value === 'true' || value === 'false') {
+					if (typeof value === "boolean") {
 						html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addBooleanParameter({
-				            count: i,
-				            key: key,
-				            value: value
-				        });
-					} else if (value.startsWith('refs/heads/')) {
-						html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addBranchParameter({
-				            count: i,
-				            key: key,
-				            value: value
-				        });
+							count: i,
+							key: key,
+							value: value
+						});
 					} else if (typeof value === 'string') {
-						html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addStringParameter({
-				            count: i,
-				            key: key,
-				            value: value
-				        });
+						if (value.startsWith('refs/heads/')) {
+							html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addBranchParameter({
+								count: i,
+								key: key,
+								value: value
+							});
+						} else {
+							html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addStringParameter({
+								count: i,
+								key: key,
+								value: value
+							});
+						}
 					} else {
 						html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addArrayParameter({
-				            count: i,
-				            key: key,
-				            value: value
-				        });
+							count: i,
+							key: key,
+							value: value
+						});
 					}
 				}
 			}


### PR DESCRIPTION
For ISSUE #54, choice params were fixed for the manual build in branch view pages. However, I did not include the fix in pb-pr-trigger.js so the manual button in the pull requests pages were still broken (as brought up by ISSUE #72). This PR adds the fix to pull requests page that was missing.