### PR TITLE
Bitbucket 5 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>2.6.9</version>
+	<version>2.7.0</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>2.7.0</version>
+	<version>3.0.0</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
@@ -20,6 +20,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import com.atlassian.bitbucket.auth.AuthenticationContext;
+import com.atlassian.bitbucket.hook.repository.RepositoryHook;
 import com.atlassian.bitbucket.i18n.I18nService;
 import com.atlassian.bitbucket.pull.PullRequest;
 import com.atlassian.bitbucket.pull.PullRequestService;
@@ -153,6 +154,22 @@ public class BuildResource extends RestResource {
 					data.add(job.asMap(variableBuilder.build()));
 				}
 			}
+			return Response.ok(data).build();
+		}
+		return Response.status(Response.Status.FORBIDDEN).build();
+	}
+
+
+	@GET
+	@Path(value = "getHookEnabled")
+	public Response getHookEnabled(@Context final Repository repository) {
+		if (authContext.isAuthenticated()) {
+			RepositoryHook hook = settingsService.getHook(repository);
+			if (hook == null) {
+				return Response.status(Response.Status.NOT_FOUND).build();
+			}
+
+			boolean data = hook.isEnabled();
 			return Response.ok(data).build();
 		}
 		return Response.status(Response.Status.FORBIDDEN).build();

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -39,7 +39,7 @@
     <resource type="download" name="hooks.css" location="/less/hooks.less"/>
     <context>bitbucket.page.repository.settings.hooks</context>
   </web-resource>
-  
+
   <!-- Pullrequest trigger button resource -->
   <web-resource key="pb-pr-trigger-resource">
     <resource type="download" name="pb-pr-trigger.js" location="/scripts/jenkins/pb-pr-trigger.js"/>
@@ -95,19 +95,13 @@
   </rest>
   
   <!-- web items -->
-  <web-item key="pr-trigger-jenkins" name="Trigger Jenkins Build From Pull Request" weight="50" section="bitbucket.pull-request.toolbar.actions">
-    <conditions type="AND">
-      <condition class="com.atlassian.bitbucket.web.conditions.PullRequestInState">
-        <param name="state">OPEN</param>
-      </condition>
-      <condition class="com.kylenicholls.stash.parameterizedbuilds.conditions.HookIsEnabledCondition"/>
-      <condition class="com.kylenicholls.stash.parameterizedbuilds.conditions.ManualButtonCondition"/>
-    </conditions>
+  <client-web-item key="pr-trigger-jenkins" name="Trigger Jenkins Build From Pull Request" weight="50" section="bitbucket.pullrequest.action">
+    <client-condition>require('jenkins/parameterized-build-pullrequest').prConditions</client-condition>
     <label>Build in Jenkins</label>
     <tooltip>Build branch in Jenkins</tooltip>
     <styleClass>parameterized-build-pullrequest</styleClass>
     <dependency>${project.groupId}-${project.artifactId}:pb-pr-trigger-resource</dependency>
-  </web-item>
+  </client-web-item>
   <client-web-item key="blayout-trigger-jenkins" name="Trigger Jenkins Builds From Branch Layout" section="bitbucket.branch.layout.actions.dropdown" weight="1000">
     <label>Build in Jenkins</label>
     <tooltip>Build branch in Jenkins</tooltip>


### PR DESCRIPTION
This took substantially longer than I thought it would...

Bitbucket 5 removes the deprecated bitbucket.pull-request.toolbar.actions for web.items for the bitbucket.pullrequest.action for client-web-items. However, the repository key is not available in the context passed to conditions in this section unlike our other client-web-items for the build dialogs. This means that the conditions we've defined will not work for this new client-web-item. Instead, client-conditions (condition functions defined in javascript) need to be specified to do the same logic as before. Since only one client-condition can be on a client-web-item (all but the first are ignored) I packaged them all into one javascript function in the script we were already loading into that item.

I'm fairly confident this should work fine. However, I have not checked how this works in Bitbucket 4.X.