### PR TITLE
Fix 3.0.0 pr build button

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,8 +239,8 @@
 		</plugins>
 	</build>
 	<properties>
-		<bitbucket.server.version>4.11.1</bitbucket.server.version>
-		<bitbucket.data.version>4.11.1</bitbucket.data.version>
+		<bitbucket.server.version>5.1.0</bitbucket.server.version>
+		<bitbucket.data.version>5.1.0</bitbucket.data.version>
 		<amps.version>6.1.0</amps.version>
 		<plugin.testrunner.version>1.2.0</plugin.testrunner.version>
 	</properties>

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
@@ -328,11 +328,11 @@ public class Jenkins {
 			logger.error("Exception for parametized build: " + message);
 			return jenkinsMessage.error(true).messageText(message).build();
 		} catch (MalformedURLException e) {
-			return jenkinsMessage.error(true).messageText("Malformed URL:" + e.getMessage())
+			return jenkinsMessage.error(true).messageText("Malformed URL: " + e.getMessage())
 					.build();
 		} catch (IOException e) {
 			logger.error("IOException in Jenkins.httpPost: " + e.getMessage(), e);
-			return jenkinsMessage.error(true).messageText("IO exception occurred" + e.getMessage())
+			return jenkinsMessage.error(true).messageText("IO exception occurred: " + e.getMessage())
 					.build();
 		} catch (Exception e) {
 			logger.error("Exception in Jenkins.httpPost: " + e.getMessage(), e);

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -46,6 +46,13 @@
     <dependency>${project.groupId}.${project.artifactId}:build-dialog</dependency>
     <context>bitbucket.page.pullRequest.view</context>
   </web-resource>
+
+  <!-- Pullrequest condition resource -->
+  <web-resource key="pb-pr-condition-resource">
+    <resource type="download" name="pb-pr-conditions.js" location="/scripts/jenkins/pb-pr-conditions.js"/>
+    <dependency>${project.groupId}.${project.artifactId}:build-dialog</dependency>
+    <context>bitbucket.page.pullRequest.view</context>
+  </web-resource>
   
   <!-- Layout trigger button resource -->
   <web-resource key="pb-blayout-trigger-resource" name="Jenkins branch build layout resource">
@@ -96,11 +103,12 @@
   
   <!-- web items -->
   <client-web-item key="pr-trigger-jenkins" name="Trigger Jenkins Build From Pull Request" weight="50" section="bitbucket.pullrequest.action">
-    <client-condition>require('jenkins/parameterized-build-pullrequest').prConditions</client-condition>
+    <client-condition>require('jenkins/parameterized-condition-pullrequest').prConditions</client-condition>
     <label>Build in Jenkins</label>
     <tooltip>Build branch in Jenkins</tooltip>
     <styleClass>parameterized-build-pullrequest</styleClass>
     <dependency>${project.groupId}-${project.artifactId}:pb-pr-trigger-resource</dependency>
+    <dependency>${project.groupId}-${project.artifactId}:pb-pr-condition-resource</dependency>
   </client-web-item>
   <client-web-item key="blayout-trigger-jenkins" name="Trigger Jenkins Builds From Branch Layout" section="bitbucket.branch.layout.actions.dropdown" weight="1000">
     <label>Build in Jenkins</label>

--- a/src/main/resources/scripts/jenkins/pb-pr-conditions.js
+++ b/src/main/resources/scripts/jenkins/pb-pr-conditions.js
@@ -1,0 +1,57 @@
+define('jenkins/parameterized-condition-pullrequest', [
+    'aui',
+    'jquery',
+    'bitbucket/internal/model/page-state',
+    'bitbucket/internal/util/ajax',
+    'aui/flag',
+    'exports'
+], function(
+    _aui,
+    $,
+    pageState,
+    ajax,
+    flag,
+    exports
+) {
+    var jobs;
+
+    exports.prConditions = function (context) {
+
+        var willDisplay = true;
+        var prJSON = context['pullRequest'];
+        var branch = prJSON.fromRef.id;
+        var commit = prJSON.fromRef.latestCommit;
+        var prDest = prJSON.toRef.displayId;
+
+        willDisplay = willDisplay && prJSON.state === 'OPEN';
+
+        var jobsUrl = getResourceUrl("getJobs") + "?branch=" + encodeURIComponent(branch) + "&commit=" + commit + "&prdestination=" + encodeURIComponent(prDest) + "&prid=" + prJSON.id;
+        var localJobs = getData(jobsUrl);
+
+        willDisplay = willDisplay && localJobs.length > 0;
+
+        var hookUrl = getResourceUrl("getHookEnabled");
+        var hookEnabled = getData(hookUrl);
+
+        return willDisplay && hookEnabled;
+    };
+
+    function getResourceUrl(resourceType){
+        return _aui.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().getKey() + '/repos/'
+            + pageState.getRepository().getSlug() + '/' + resourceType;
+    }
+
+    function getData(resourceUrl){
+        var results;
+        $.ajax({
+            type: "GET",
+            url: resourceUrl,
+            dataType: 'json',
+            async: false,
+            success: function (data){
+                results = data;
+            }
+        });
+        return results;
+    }
+});

--- a/src/main/resources/scripts/jenkins/pb-pr-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-pr-trigger.js
@@ -1,80 +1,57 @@
 define('jenkins/parameterized-build-pullrequest', [
-  'aui',
-  'jquery',
-  'bitbucket/internal/model/page-state',
-  'bitbucket/internal/util/ajax',
-  'aui/flag',
-  'exports'
+    'aui',
+    'jquery',
+    'bitbucket/internal/model/page-state',
+    'bitbucket/internal/util/ajax',
+    'aui/flag'
 ], function(
-   _aui,
-   $,
-   pageState,
-   ajax,
-   flag,
-   exports
+    _aui,
+    $,
+    pageState,
+    ajax,
+    flag
 ) {
-	var jobs;
+    var jobs;
 
-	exports.prConditions = function (context) {
+    $(".parameterized-build-pullrequest").click(function() {
+        var prJSON = require('bitbucket/internal/model/page-state').getPullRequest().toJSON();
+        var branch = prJSON.fromRef.id;
+        var commit = prJSON.fromRef.latestCommit;
+        var prDest = prJSON.toRef.displayId;
 
-		var willDisplay = true;
-		var prJSON = context['pullRequest'];
-		var branch = prJSON.fromRef.id;
-		var commit = prJSON.fromRef.latestCommit;
-		var prDest = prJSON.toRef.displayId;
+        var resourceUrl = getResourceUrl("getJobs") + "?branch=" + encodeURIComponent(branch) + "&commit=" + commit + "&prdestination=" + encodeURIComponent(prDest) + "&prid=" + prJSON.id;
 
-		willDisplay = willDisplay && prJSON.state === 'OPEN';
+        jobs = getJobs(resourceUrl);
+        if (jobs.length == 1){
+            if (jobs[0].buildParameters.length == 0){
+                var buildUrl = getResourceUrl("triggerBuild/0");
+                triggerBuild(buildUrl);
+                return false;
+            }
+        }
+        var buildUrl = getResourceUrl("triggerBuild");
+        showManualBuildDialog(buildUrl);
+        return false;
+    });
 
-		var jobsUrl = getResourceUrl("getJobs") + "?branch=" + encodeURIComponent(branch) + "&commit=" + commit + "&prdestination=" + encodeURIComponent(prDest) + "&prid=" + prJSON.id;
-		var localJobs = getData(jobsUrl);
+    function getResourceUrl(resourceType){
+        return _aui.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().getKey() + '/repos/'
+            + pageState.getRepository().getSlug() + '/' + resourceType;
+    }
 
-		willDisplay = willDisplay && localJobs.length > 0;
-
-		var hookUrl = getResourceUrl("getHookEnabled");
-		var hookEnabled = getData(hookUrl);
-
-		return willDisplay && hookEnabled;
-	};
-
-	$(".parameterized-build-pullrequest").click(function() {
-		var prJSON = require('bitbucket/internal/model/page-state').getPullRequest().toJSON();
-		var branch = prJSON.fromRef.id;
-		var commit = prJSON.fromRef.latestCommit;
-		var prDest = prJSON.toRef.displayId;
-
-		var jobsUrl = getResourceUrl("getJobs") + "?branch=" + encodeURIComponent(branch) + "&commit=" + commit + "&prdestination=" + encodeURIComponent(prDest) + "&prid=" + prJSON.id;
-
-		jobs = getData(jobsUrl);
-    	if (jobs.length == 1){
-        	if (jobs[0].buildParameters.length == 0){
-        		var buildUrl = getResourceUrl("triggerBuild/0");
-        		triggerBuild(buildUrl);
-            	return false;
-        	}
-    	}
-		var buildUrl = getResourceUrl("triggerBuild");
-    	showManualBuildDialog(buildUrl);
-    	return false;
-	});
-
-	function getResourceUrl(resourceType){
-		return _aui.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().getKey() + '/repos/'
-        + pageState.getRepository().getSlug() + '/' + resourceType;
-	}
-
-	function getData(resourceUrl){
-		var results;
-		$.ajax({
-		  type: "GET",
-		  url: resourceUrl,
-		  dataType: 'json',
-		  async: false,
-		  success: function (data){
-			  results = data;
-		  }
-		});
-		return results;
-	}
+    function getJobs(resourceUrl){
+        var results;
+        $.ajax({
+            type: "GET",
+            url: resourceUrl,
+            dataType: 'json',
+            async: false,
+            success: function (data){
+                results = data;
+            }
+        });
+        return results;
+    }
 
     function showManualBuildDialog(buildUrl) {
         var dialog = _aui.dialog2(aui.dialog.dialog2({
@@ -93,131 +70,131 @@ define('jenkins/parameterized-build-pullrequest', [
         dialog.$el.find('form').on('submit', function(e) { e.preventDefault(); });
         dialog.$el.find('#start-build').on('click', function() {
             _.defer(function() {
-            	var $jobParameters = dialog.$el.find('.jenkins-form');
-            	var jobSelect = document.getElementById("job");
+                var $jobParameters = dialog.$el.find('.jenkins-form');
+                var jobSelect = document.getElementById("job");
                 var id = jobSelector.options[jobSelector.selectedIndex].value;
-            	buildUrl += "/" + jobs[id].id + "?";
-            	$jobParameters.each(function(index, jobParam) {
-            		var $curJobParam = $(jobParam);
-            		var key = $curJobParam.find('label').text();
-            		var value = dialog.$el.find('#build-param-value-' + index).val();
-            		var type = $(dialog.$el.find('#build-param-value-' + index)[0]).attr('class');
-            		if (type.indexOf("checkbox") > -1) {
-            			value = dialog.$el.find('#build-param-value-' + index)[0].checked;
-            		} else if (type.indexOf("hidden") > -1) {
-            			value = value.replace('refs/heads/','');
-					}
-            		buildUrl += key + "=" + encodeURIComponent(value) + "&";
-            	});
-            	triggerBuild(buildUrl.slice(0,-1));
+                buildUrl += "/" + jobs[id].id + "?";
+                $jobParameters.each(function(index, jobParam) {
+                    var $curJobParam = $(jobParam);
+                    var key = $curJobParam.find('label').text();
+                    var value = dialog.$el.find('#build-param-value-' + index).val();
+                    var type = $(dialog.$el.find('#build-param-value-' + index)[0]).attr('class');
+                    if (type.indexOf("checkbox") > -1) {
+                        value = dialog.$el.find('#build-param-value-' + index)[0].checked;
+                    } else if (type.indexOf("hidden") > -1) {
+                        value = value.replace('refs/heads/','');
+                    }
+                    buildUrl += key + "=" + encodeURIComponent(value) + "&";
+                });
+                triggerBuild(buildUrl.slice(0,-1));
                 dialog.hide();
             });
         }).focus().select();
     }
 
-	$(document).on('change', '#job', function(e) {
-    	e.preventDefault();
-    	setupJobForm(jobs[this.value]);
+    $(document).on('change', '#job', function(e) {
+        e.preventDefault();
+        setupJobForm(jobs[this.value]);
     });
 
-	function setupJobForm(job) {
-		var $container = $('.job-params');
+    function setupJobForm(job) {
+        var $container = $('.job-params');
 
-		var html = '<div class="job-params">';
-		var parameters = job.buildParameters;
-		if (parameters) {
-			for (i = 0; i < parameters.length; i++) {
-				var keyValue = parameters[i];
-				for (var key in keyValue){
-					var value = keyValue[key];
-					if (typeof value === "boolean") {
-						html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addBooleanParameter({
-							count: i,
-							key: key,
-							value: value
-						});
-					} else if (typeof value === 'string') {
-						if (value.startsWith('refs/heads/')) {
-							html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addBranchParameter({
-								count: i,
-								key: key,
-								value: value
-							});
-						} else {
-							html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addStringParameter({
-								count: i,
-								key: key,
-								value: value
-							});
-						}
-					} else {
-						html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addArrayParameter({
-							count: i,
-							key: key,
-							value: value
-						});
-					}
-				}
-			}
-		}
-		$container.replaceWith(html + "</div>");
-	}
+        var html = '<div class="job-params">';
+        var parameters = job.buildParameters;
+        if (parameters) {
+            for (i = 0; i < parameters.length; i++) {
+                var keyValue = parameters[i];
+                for (var key in keyValue){
+                    var value = keyValue[key];
+                    if (typeof value === "boolean") {
+                        html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addBooleanParameter({
+                            count: i,
+                            key: key,
+                            value: value
+                        });
+                    } else if (typeof value === 'string') {
+                        if (value.startsWith('refs/heads/')) {
+                            html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addBranchParameter({
+                                count: i,
+                                key: key,
+                                value: value
+                            });
+                        } else {
+                            html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addStringParameter({
+                                count: i,
+                                key: key,
+                                value: value
+                            });
+                        }
+                    } else {
+                        html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addArrayParameter({
+                            count: i,
+                            key: key,
+                            value: value
+                        });
+                    }
+                }
+            }
+        }
+        $container.replaceWith(html + "</div>");
+    }
 
-	function triggerBuild(buildUrl){
-		var successFlag = flag({
+    function triggerBuild(buildUrl){
+        var successFlag = flag({
             type: 'success',
             body: 'Build started',
             close: 'auto'
         });
-		ajax.rest({
-		  type: "POST",
-		  url: buildUrl,
-		  dataType: 'json',
-		  async: true
-		}).success(function (data) {
-    		if (data.error){
-    			successFlag.close();
-    			flag({
+        ajax.rest({
+            type: "POST",
+            url: buildUrl,
+            dataType: 'json',
+            async: true
+        }).success(function (data) {
+            if (data.error){
+                successFlag.close();
+                flag({
                     type: 'warning',
                     body: data.messageText,
                     close: 'auto'
                 });
-    		} else if (data.prompt) {
-    			var promptCookie = getCookie("jenkinsPrompt");
-    			var settingsPath = _aui.contextPath() + "/plugins/servlet/account/jenkins";
-    			if (promptCookie !== "ignore") {
-	    			flag({
-	                    type: 'info',
-	                    body: '<p>Optional: <a href="' + settingsPath +
-	                    '" target="_blank">You can link your Jenkins account to your Bitbucket account.</a></p>' +
-	                    '<br/><label><input id="prompt-cookie" type="checkbox" /><span>Don\'t show again</span></label>'
-	                });
-    			}
-    		}
-		});
-	};
+            } else if (data.prompt) {
+                var promptCookie = getCookie("jenkinsPrompt");
+                var settingsPath = _aui.contextPath() + "/plugins/servlet/account/jenkins";
+                if (promptCookie !== "ignore") {
+                    flag({
+                        type: 'info',
+                        body: '<p>Optional: <a href="' + settingsPath +
+                        '" target="_blank">You can link your Jenkins account to your Bitbucket account.</a></p>' +
+                        '<br/><label><input id="prompt-cookie" type="checkbox" /><span>Don\'t show again</span></label>'
+                    });
+                }
+            }
+        });
+    };
 
-	$(document).on('change', '#prompt-cookie', function(e) {
-		var d = new Date();
-	    d.setTime(d.getTime() + (365*24*60*60*1000));
-	    var expires = "expires="+ d.toUTCString();
-		document.cookie = "jenkinsPrompt=ignore;" + expires + ";path=/";
+    $(document).on('change', '#prompt-cookie', function(e) {
+        var d = new Date();
+        d.setTime(d.getTime() + (365*24*60*60*1000));
+        var expires = "expires="+ d.toUTCString();
+        document.cookie = "jenkinsPrompt=ignore;" + expires + ";path=/";
     });
 
-	function getCookie(cname) {
-	    var name = cname + "=";
-	    var ca = document.cookie.split(';');
-	    for(var i = 0; i <ca.length; i++) {
-	        var c = ca[i];
-	        while (c.charAt(0)==' ') {
-	            c = c.substring(1);
-	        }
-	        if (c.indexOf(name) == 0) {
-	            return c.substring(name.length,c.length);
-	        }
-	    }
-	    return "";
-	}
+    function getCookie(cname) {
+        var name = cname + "=";
+        var ca = document.cookie.split(';');
+        for(var i = 0; i <ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0)==' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) == 0) {
+                return c.substring(name.length,c.length);
+            }
+        }
+        return "";
+    }
 });
 
 AJS.$(document).ready(function() {


### PR DESCRIPTION
Turns out the updates to the pb-pr-trigger.js script caused the button to not load the build dialog elements so it would do absolutely nothing. To fix this, I've reverted  pb-pr-trigger.js file to the previous version and moved the pr-conditions function to a file new, pb-pr-conditions.js. This allows the conditions to function independently from the trigger so no unintended side effects are present.
I don't know if we want to release this as a 3.0.1 release or if there's a way to replace the released version on bitbucket.

Later, I would like to fix up this section of code so that there isn't so much repetitive code between build-dialog, pb-pr-trigger, and pb-pr-conditions. However, for now its more important that the latest release works.