### PR TITLE
Fix duplicate calls when Build Token Root Plugin used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>3.1.0</version>
+	<version>3.1.1</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
@@ -284,7 +284,10 @@ public class Jenkins {
 	}
 
 	private String getCrumb(String buildUrl, String token) throws Exception{
-		String crumbUrl = buildUrl.split("/job/")[0]  + "/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)";
+		URL url = new URL(buildUrl);
+		String port = url.getPort() == -1 ? "" : ":" + Integer.toString(url.getPort());
+		String jenkins_url = url.getProtocol() + "://" + url.getHost() + port;
+		String crumbUrl = jenkins_url  + "/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)";
 		HttpURLConnection connection = setupConnection(crumbUrl, token);
 		connection.connect();
 		int status = connection.getResponseCode();


### PR DESCRIPTION
As mentioned in #71, When Build Token Root Plugin is enabled, two builds will be triggered instead of one. This is due to the naive way the base url was being parsed from the jenkins rest url that triggers the job when trying to get the crumb. This PR fixes this by using the URL lib to rebuild the base url instead.

I have manually tested this with both Build Token Root Plugin enabled and disabled and both CSRF protection enabled and disabled. All cases behave as expected.