### PR TITLE
Added $FROMCOMMIT variable

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
@@ -75,6 +75,7 @@ public class ParameterizedBuildHook
 		String url = applicationPropertiesService.getBaseUrl().toString();
 		BitbucketVariables bitbucketVariables = new BitbucketVariables.Builder().branch(branch)
 				.commit(commit).url(url).repoName(repository.getSlug()).projectName(projectKey)
+				.fromCommit(refChange.getFromHash())
 				.prId(0).prAuthor("").prTitle("").prDescription("").prUrl("").build();
 
 		for (Job job : settingsService.getJobs(context.getSettings().asMap())) {

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHook.java
@@ -115,6 +115,7 @@ public class PullRequestHook {
 		String projectKey = repository.getProject().getKey();
 		String branch = pullRequest.getFromRef().getDisplayId();
 		String commit = pullRequest.getFromRef().getLatestCommit();
+		String fromCommit = pullRequest.getToRef().getLatestCommit();
 		String url = applicationPropertiesService.getBaseUrl().toString();
 		long prId = pullRequest.getId();
 		String prAuthor = pullRequest.getAuthor().getUser().getDisplayName();
@@ -124,6 +125,7 @@ public class PullRequestHook {
 		String prUrl = url + "/projects/" + projectKey + "/repos/" + repository.getSlug() + "/pull-requests/" + prId;
 		BitbucketVariables.Builder builder = new BitbucketVariables.Builder().branch(branch)
 				.commit(commit).url(url).prId(prId).prAuthor(prAuthor).prTitle(prTitle)
+				.fromCommit(fromCommit)
 				.prDestination(prDest).prUrl(prUrl)
 				.repoName(repository.getSlug())
 				.projectName(projectKey);

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/BitbucketVariables.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/BitbucketVariables.java
@@ -36,6 +36,11 @@ public class BitbucketVariables {
 			variables.add(new SimpleEntry<>("$COMMIT", commit));
 			return this;
 		}
+		public Builder fromCommit(String commit) {
+			Preconditions.checkNotNull(commit);
+			variables.add(new SimpleEntry<>("$FROMCOMMIT", commit));
+			return this;
+		}
 
 		public Builder prDestination(String prDestination) {
 			Preconditions.checkNotNull(prDestination);

--- a/src/main/resources/static/parameterized-build-hook.soy
+++ b/src/main/resources/static/parameterized-build-hook.soy
@@ -126,7 +126,7 @@
 	        {param value: $buildParameters /}
 	        {param labelContent: 'Build Parameters'  /}
         	{param descriptionText: 'Key=Value pairs separated by new line. 
-        		For choice parameters separate values with a semicolon. Available Bitbucket variables: $BRANCH, $COMMIT, $REPOSITORY, $PROJECT (for PR triggers also $PRID, $PRTITLE, $PRDESTINATION, $PRAUTHOR, $PRDESCRIPTION, $PRURL)'/}
+        		For choice parameters separate values with a semicolon. Available Bitbucket variables: $BRANCH, $COMMIT, $FROMCOMMIT, $REPOSITORY, $PROJECT (for PR triggers also $PRID, $PRTITLE, $PRDESTINATION, $PRAUTHOR, $PRDESCRIPTION, $PRURL)'/}
 			{param rows: 3 /}
 	        {param extraClass: 'long-field' /}
 			{param fieldWidth: 'full-width' /}

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHookTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHookTest.java
@@ -39,6 +39,7 @@ public class ParameterizedBuildHookTest {
 	private final String BRANCH_REF = "refs/heads/branch";
 	private final String PROJECT_KEY = "projectkey";
 	private final String COMMIT = "commithash";
+	private final String COMMITFROM = "commithashfrom";
 	private final String REPO_SLUG = "reposlug";
 	private final String URI = "http://uri";
 	private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false);
@@ -83,6 +84,7 @@ public class ParameterizedBuildHookTest {
 		when(context.getRepository()).thenReturn(repository);
 		when(refChange.getRef()).thenReturn(minimalRef);
 		when(refChange.getToHash()).thenReturn(COMMIT);
+		when(refChange.getFromHash()).thenReturn(COMMITFROM);
 		when(context.getSettings()).thenReturn(settings);
 		when(repository.getSlug()).thenReturn(REPO_SLUG);
 		when(repository.getProject()).thenReturn(project);

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHookTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHookTest.java
@@ -45,6 +45,7 @@ public class PullRequestHookTest {
 	private final String SOURCE_BRANCH = "sourcebranch";
 	private final String DEST_BRANCH = "destbranch";
 	private final String COMMIT = "commithash";
+	private final String COMMITFROM = "commithashfrom";
 	private final String REPO_SLUG = "reposlug";
 	private final String PROJECT_NAME = "projectname";
 	private final String USER_DISPLAY_NAME = "userdisplayname";
@@ -122,6 +123,7 @@ public class PullRequestHookTest {
 		when(prFromRef.getDisplayId()).thenReturn(SOURCE_BRANCH);
 		when(prFromRef.getLatestCommit()).thenReturn(COMMIT);
 		when(prToRef.getDisplayId()).thenReturn(DEST_BRANCH);
+		when(prToRef.getLatestCommit()).thenReturn(COMMITFROM);
 		when(settingsService.getSettings(repository)).thenReturn(settings);
 		when(jenkins.getJenkinsServer()).thenReturn(globalServer);
 		when(propertiesService.getBaseUrl()).thenReturn(new URI(PR_URI));


### PR DESCRIPTION
In some cases, we need to know differences between 2 git commits that are not directly linked together.

For example, if I work locally and I do 8 commits in a row with different operations (modification, deletion, etc) and I push the branch, only the last commit ID is read and because of this, we are unable to find all the changed files since those last 8 commits.

With this PR, we can do a diff between the latest commit ($COMMIT) and the last commit before the push ($FROMCOMMIT) and that way we are sure to catch all the modifications.