### PR TITLE
Create Filter for PR Destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ build for branches/tags that match the filter
   * leave blank to match all changes
 * `Required Build Permission` will restrict who can trigger a Jenkins job using the repository permissions
   * This is only available on manual triggers
+* `PR Destination Filter` functions identically to `Ref Filter` but on the branch being merged into
 
 #### Link your bitbucket server account to Jenkins
 ![Jenkins user settings](readme/img/jenkins_user.png)  

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>3.1.1</version>
+	<version>3.1.2</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHook.java
@@ -143,6 +143,7 @@ public class PullRequestHook {
 		for (final Job job : settingsService.getJobs(settings.asMap())) {
 			List<Trigger> triggers = job.getTriggers();
 			final String pathRegex = job.getPathRegex();
+			final String prDestRegex = job.getPrDestRegex();
 
 			if (triggers.contains(trigger)) {
 				Server jenkinsServer = jenkins.getJenkinsServer(projectKey);
@@ -167,6 +168,11 @@ public class PullRequestHook {
 
 				final String token = joinedUserToken;
 				final boolean finalPrompt = prompt;
+				String prDest = pullRequest != null ? pullRequest.getToRef().getDisplayId() : "";
+
+				if (!(prDestRegex.trim().isEmpty() || prDest.toLowerCase().matches(prDestRegex.toLowerCase()))) {
+					return;
+				}
 
 				if (pathRegex.trim().isEmpty()) {
 					jenkins.triggerJob(buildUrl, token, finalPrompt);

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
@@ -27,6 +27,7 @@ public class SettingsService {
 	public static final String BRANCH_PREFIX = "branchRegex-";
 	public static final String PATH_PREFIX = "pathRegex-";
 	public static final String PERMISSIONS_PREFIX = "requirePermission-";
+	public static final String PRDEST_PREFIX = "prDestinationRegex-";
 
 	private RepositoryHookService hookService;
 	private SecurityService securityService;
@@ -95,6 +96,8 @@ public class SettingsService {
 								.toString())
 						.permissions(fetchValue(entry.getKey().replace(JOB_PREFIX, PERMISSIONS_PREFIX),
 								parameterMap, "REPO_READ"))
+						.prDestRegex(parameterMap.get(entry.getKey().replace(JOB_PREFIX, PRDEST_PREFIX))
+								.toString())
 						.build();
 
 				jobsList.add(job);

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
@@ -27,6 +27,7 @@ public class Job {
 	private final String branchRegex;
 	private final String pathRegex;
 	private final String permissions;
+	private final String prDestRegex;
 
 	private Job(JobBuilder builder) {
 		this.jobId = builder.jobId;
@@ -38,6 +39,7 @@ public class Job {
 		this.branchRegex = builder.branchRegex;
 		this.pathRegex = builder.pathRegex;
 		this.permissions = builder.permissions;
+		this.prDestRegex = builder.prDestRegex;
 	}
 
 	public int getJobId() {
@@ -76,6 +78,10 @@ public class Job {
 		return permissions;
 	}
 
+	public String getPrDestRegex() {
+		return prDestRegex;
+	}
+
 	public Map<String, Object> asMap(BitbucketVariables bitbucketVariables) {
 		Map<String, Object> map = new LinkedHashMap<>();
 		map.put("id", jobId);
@@ -106,6 +112,7 @@ public class Job {
 		private String branchRegex;
 		private String pathRegex;
 		private String permissions;
+		private String prDestRegex;
 
 		public JobBuilder(int jobId) {
 			this.jobId = jobId;
@@ -180,6 +187,11 @@ public class Job {
 
 		public JobBuilder permissions(String permissions) {
 			this.permissions = permissions;
+			return this;
+		}
+
+		public JobBuilder prDestRegex(String prDestRegex) {
+			this.prDestRegex = prDestRegex;
 			return this;
 		}
 

--- a/src/main/resources/less/hooks.less
+++ b/src/main/resources/less/hooks.less
@@ -27,3 +27,7 @@
 .hide-permissions {
     display:none;
 }
+
+.hide-pr-dest {
+    display:none;
+}

--- a/src/main/resources/static/parameterized-build-hook.js
+++ b/src/main/resources/static/parameterized-build-hook.js
@@ -37,7 +37,7 @@
             '.pr-auto-merged':
                 {
                     'trigger': 'prautomerged;',
-                    'extraFields': ['#pathRegex-', '#prDestinationRegex-']
+                    'extraFields': []
                 },
             '.pr-declined':
                 {

--- a/src/main/resources/static/parameterized-build-hook.js
+++ b/src/main/resources/static/parameterized-build-hook.js
@@ -27,22 +27,22 @@
             '.pr-opened':
                 {
                     'trigger': 'pullrequest;',
-                    'extraFields': ['#pathRegex-']
+                    'extraFields': ['#pathRegex-', '#prDestinationRegex-']
                 },
             '.pr-merged':
                 {
                     'trigger': 'prmerged;',
-                    'extraFields': ['#pathRegex-']
+                    'extraFields': ['#pathRegex-', '#prDestinationRegex-']
                 },
             '.pr-auto-merged':
                 {
                     'trigger': 'prautomerged;',
-                    'extraFields': ['#pathRegex-']
+                    'extraFields': ['#pathRegex-', '#prDestinationRegex-']
                 },
             '.pr-declined':
                 {
                     'trigger': 'prdeclined;',
-                    'extraFields': ['#pathRegex-']
+                    'extraFields': ['#pathRegex-', '#prDestinationRegex-']
                 }
         };
 
@@ -60,6 +60,10 @@
             },
             '#requirePermission-': {
                 'class' : 'hide-permissions',
+                'triggers' : []
+            },
+            '#prDestinationRegex-': {
+                'class' : 'hide-pr-dest',
                 'triggers' : []
             }
         };
@@ -149,6 +153,7 @@
             'path' : '',
             'param' : '',
             'permissions' : '',
+            'prDestinationRegex': '',
             'collapsed' : false
         });
         $(html).insertBefore($(this));
@@ -220,6 +225,10 @@
                 if (index2 === 8) {
                     $(currentField).find('label').attr('for', 'requirePermission-' + index);
                     $(currentField).find('select').attr('id', 'requirePermission-' + index).attr('name', 'requirePermission-' + index);
+                }
+                if (index2 === 9) {
+                    $(currentField).find('label').attr('for', 'prDestinationRegex-' + index);
+                    $(currentField).find('select').attr('id', 'prDestinationRegex-' + index).attr('name', 'prDestinationRegex-' + index);
                 }
             });
         });

--- a/src/main/resources/static/parameterized-build-hook.soy
+++ b/src/main/resources/static/parameterized-build-hook.soy
@@ -181,7 +181,7 @@
             {call .setHideClasses}
                 {param collapsed: $collapsed /}
                 {param triggers: $triggers /}
-                {param valid_triggers: ['push;', 'pullrequest;', 'prmerged;', 'prdeclined;', 'prautomerged;'] /}
+                {param valid_triggers: ['push;', 'pullrequest;', 'prmerged;', 'prdeclined;'] /}
                 {param class: 'hide-paths' /}
             {/call}
         {/let}
@@ -223,7 +223,7 @@
             {call .setHideClasses}
                 {param collapsed: $collapsed /}
                 {param triggers: $triggers /}
-                {param valid_triggers: ['pullrequest;', 'prmerged;', 'prdeclined;', 'prautomerged;'] /}
+                {param valid_triggers: ['pullrequest;', 'prmerged;', 'prdeclined;'] /}
                 {param class: 'hide-pr-dest' /}
             {/call}
         {/let}

--- a/src/main/resources/static/parameterized-build-hook.soy
+++ b/src/main/resources/static/parameterized-build-hook.soy
@@ -36,7 +36,7 @@
                 <div class="field-group"><div class="error">{$errors['jenkins-admin-error']}</div></div>
         {/if}
         {let $configKeys: $config ? keys($config) : [] /}
-        {let $visibleInputsCount: $configKeys.length > 0 ? ($configKeys.length / 8) : 1 /}
+        {let $visibleInputsCount: $configKeys.length > 0 ? ($configKeys.length / 9) : 1 /}
         {for $i in range($visibleInputsCount)}
             {call .addJob}
                 {param canDelete: $visibleInputsCount > 1 /}
@@ -49,6 +49,7 @@
                 {param branchRegex: $config and $config['branchRegex-' + $i] ? $config['branchRegex-' + $i] : null /}
                 {param pathRegex: $config and $config['pathRegex-' + $i] ? $config['pathRegex-' + $i] : null /}
                 {param requirePermission: $config and $config['requirePermission-' + $i] ? $config['requirePermission-' + $i] : null /}
+                {param prDestinationRegex: $config and $config['prDestinationRegex-' + $i] ? $config['prDestinationRegex-' + $i] : null /}
                 {param errors: $errors ? $errors : null /}
                 {param collapsed: not $errors and $configKeys.length > 0 /}
             {/call}
@@ -74,6 +75,7 @@
  * @param branchRegex
  * @param pathRegex
  * @param requirePermission
+ * @param prDestinationRegex
  * @param errors
  * @param collapsed
  */
@@ -217,6 +219,23 @@
             {param descriptionText: 'Only allow users with the given repository permission or higher to trigger this job.' /}
             {param extraClasses: $permissionsClasses /}
         {/call}
-        <hr>
+        {let $pathClasses}
+            {call .setHideClasses}
+                {param collapsed: $collapsed /}
+                {param triggers: $triggers /}
+                {param valid_triggers: ['pullrequest;', 'prmerged;', 'prdeclined;', 'prautomerged;'] /}
+                {param class: 'hide-pr-dest' /}
+            {/call}
+        {/let}
+        {call aui.form.textField}
+            {param id: 'prDestinationRegex-' + $count /}
+            {param value: $prDestinationRegex /}
+            {param labelContent: 'PR Desitination Filter'  /}
+            {param extraClass: 'long-field' /}
+            {param fieldWidth: 'full-width' /}
+            {param descriptionText: 'Trigger builds if the pull request destination matches the regex (example: "release.*|hotfix.*|production"). Supported triggers: AUTO MERGE, PR OPENED, PR MERGED, PR DECLINED' /}
+            {param extraClasses: $pathClasses /}
+        {/call}
+<hr>
     </div>
 {/template}

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsServiceTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsServiceTest.java
@@ -42,6 +42,7 @@ public class SettingsServiceTest {
 		String branchRegex = "branchRegex";
 		String pathRegex = "pathRegex";
 		String permissions = "permissions";
+		String prDestRegex = "prDestinationRegex";
 		Map<String, Object> jobConfig = new LinkedHashMap<>();
 		jobConfig.put(SettingsService.JOB_PREFIX + "0", jobName);
 		jobConfig.put(SettingsService.TRIGGER_PREFIX + "0", triggers);
@@ -50,6 +51,7 @@ public class SettingsServiceTest {
 		jobConfig.put(SettingsService.BRANCH_PREFIX + "0", branchRegex);
 		jobConfig.put(SettingsService.PATH_PREFIX + "0", pathRegex);
 		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "0", permissions);
+		jobConfig.put(SettingsService.PRDEST_PREFIX + "0", prDestRegex);
 		jobConfig.put(SettingsService.JOB_PREFIX + "1", jobName2);
 		jobConfig.put(SettingsService.TRIGGER_PREFIX + "1", "add");
 		jobConfig.put(SettingsService.PARAM_PREFIX + "1", "");
@@ -57,6 +59,7 @@ public class SettingsServiceTest {
 		jobConfig.put(SettingsService.BRANCH_PREFIX + "1", "");
 		jobConfig.put(SettingsService.PATH_PREFIX + "1", "");
 		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "1", "");
+		jobConfig.put(SettingsService.PRDEST_PREFIX + "1", "");
 		List<Job> jobs = settingsService.getJobs(jobConfig);
 
 		List<Trigger> triggerList = Arrays.asList(Trigger.ADD, Trigger.PUSH);
@@ -70,6 +73,7 @@ public class SettingsServiceTest {
 		assertEquals(branchRegex, jobs.get(0).getBranchRegex());
 		assertEquals(pathRegex, jobs.get(0).getPathRegex());
 		assertEquals(1, jobs.get(1).getJobId());
+		assertEquals(prDestRegex, jobs.get(0).getPrDestRegex());
 		assertEquals(jobName2, jobs.get(1).getJobName());
 	}
 
@@ -91,6 +95,7 @@ public class SettingsServiceTest {
 		jobConfig.put(SettingsService.BRANCH_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PATH_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "0", "");
+		jobConfig.put(SettingsService.PRDEST_PREFIX + "0", "");
 		List<Job> jobs = settingsService.getJobs(jobConfig);
 
 		assertFalse(jobs.get(0).getIsTag());
@@ -107,6 +112,7 @@ public class SettingsServiceTest {
 		jobConfig.put(SettingsService.BRANCH_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PATH_PREFIX + "0", "");
 		jobConfig.put(SettingsService.PERMISSIONS_PREFIX + "0", "");
+		jobConfig.put(SettingsService.PRDEST_PREFIX + "0", "");
 		List<Job> jobs = settingsService.getJobs(jobConfig);
 
 		assertTrue(jobs.get(0).getIsTag());


### PR DESCRIPTION
As requested by Issue #38 and #86, this PR adds the ability to restrict when Jenkins jobs are triggered via a PR Destination regex.

#86 also requested a filter for the source branch. While this would be simple enough, I don't like how the PR java logic is becoming somewhat spaghetti with this feature and would like to investigate cleaning it up before adding another conditional field.