### PR TITLE
Move hook processing from event thread to dedicated thread pool via an

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHook.java
@@ -1,6 +1,7 @@
 package com.kylenicholls.stash.parameterizedbuilds;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 
 import com.atlassian.bitbucket.event.pull.*;
 import com.atlassian.bitbucket.pull.PullRequest;
@@ -8,6 +9,7 @@ import com.atlassian.bitbucket.pull.PullRequestService;
 import com.atlassian.bitbucket.repository.Branch;
 import com.atlassian.bitbucket.server.ApplicationPropertiesService;
 import com.atlassian.event.api.EventListener;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.kylenicholls.stash.parameterizedbuilds.ciserver.Jenkins;
 import com.kylenicholls.stash.parameterizedbuilds.eventHandlers.*;
 import com.kylenicholls.stash.parameterizedbuilds.helper.SettingsService;
@@ -18,25 +20,31 @@ public class PullRequestHook {
 	private final PullRequestService pullRequestService;
 	private final Jenkins jenkins;
 	private final String url;
+	private final ExecutorService executorService;
 
-	public PullRequestHook(SettingsService settingsService, PullRequestService pullRequestService,
-			Jenkins jenkins, ApplicationPropertiesService applicationPropertiesService) {
+	public PullRequestHook(
+			SettingsService settingsService,
+			PullRequestService pullRequestService,
+			Jenkins jenkins,
+			ApplicationPropertiesService applicationPropertiesService,
+			@ComponentImport
+			ExecutorService executorService) {
+
 		this.settingsService = settingsService;
 		this.pullRequestService = pullRequestService;
 		this.jenkins = jenkins;
 		this.url = applicationPropertiesService.getBaseUrl().toString();
+		this.executorService = executorService;
 	}
 
 	@EventListener
 	public void onPullRequestOpened(PullRequestOpenedEvent event) throws IOException {
-		PROpenedHandler prOpened = new PROpenedHandler(settingsService, pullRequestService, jenkins, event, url);
-		prOpened.run();
+		runHandler(new PROpenedHandler(settingsService, pullRequestService, jenkins, event, url));
 	}
 
 	@EventListener
 	public void onPullRequestReOpened(PullRequestReopenedEvent event) throws IOException {
-		PROpenedHandler prOpened = new PROpenedHandler(settingsService, pullRequestService, jenkins, event, url);
-		prOpened.run();
+		runHandler(new PROpenedHandler(settingsService, pullRequestService, jenkins, event, url));
 	}
 
 	@EventListener
@@ -46,30 +54,26 @@ public class PullRequestHook {
 		// updated. We only want to trigger builds if the source commit hash
 		// changes
 		if (!event.getPreviousFromHash().equals(pullRequest.getFromRef().getLatestCommit())) {
-			PROpenedHandler prOpened = new PROpenedHandler(settingsService, pullRequestService, jenkins, event, url);
-			prOpened.run();
+			runHandler(new PROpenedHandler(settingsService, pullRequestService, jenkins, event, url));
 		}
 	}
 
 	@EventListener
 	public void onPullRequestMerged(PullRequestMergedEvent event) throws IOException {
-		PRMergedHandler prMerged = new PRMergedHandler(settingsService, pullRequestService, jenkins, event, url);
-		prMerged.run();
+		runHandler(new PRMergedHandler(settingsService, pullRequestService, jenkins, event, url));
 	}
 
 	@EventListener
 	public void onPullRequestAutomaticMerged(AutomaticMergeEvent event) throws IOException {
 		Iterable<Branch> branches = event.getMergePath();
 		for (Branch branch : branches){
-			PRAutoMergedHandler prAutoMerge = new PRAutoMergedHandler(settingsService, jenkins, event, url, branch);
-			prAutoMerge.run();
+			runHandler(new PRAutoMergedHandler(settingsService, jenkins, event, url, branch));
 		}
 	}
 
 	@EventListener
 	public void onPullRequestDeclined(PullRequestDeclinedEvent event) throws IOException {
-		PRDeclinedHandler prDeclined = new PRDeclinedHandler(settingsService, pullRequestService, jenkins, event, url);
-		prDeclined.run();
+		runHandler(new PRDeclinedHandler(settingsService, pullRequestService, jenkins, event, url));
 	}
 
 	@EventListener
@@ -77,11 +81,14 @@ public class PullRequestHook {
 		try {
 			Class PRDeletedEvent = Class.forName("com.atlassian.bitbucket.event.pull.PullRequestDeletedEvent");
 			if (PRDeletedEvent.isInstance(event)) {
-				PRDeletedHandler prDeleted = new PRDeletedHandler(settingsService, pullRequestService, jenkins, event, url);
-				prDeleted.run();
+				runHandler(new PRDeletedHandler(settingsService, pullRequestService, jenkins, event, url));
 			}
 		} catch (ClassNotFoundException e) {
 			return;
 		}
+	}
+
+	protected void runHandler(BaseHandler handler) {
+		this.executorService.submit(() -> handler.run());
 	}
 }

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHookTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHookTest.java
@@ -1,25 +1,8 @@
 package com.kylenicholls.stash.parameterizedbuilds;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import com.atlassian.bitbucket.hook.repository.RepositoryHookRequest;
-import com.kylenicholls.stash.parameterizedbuilds.eventHandlers.PushHandler;
-import com.kylenicholls.stash.parameterizedbuilds.eventHandlers.RefCreatedHandler;
-import com.kylenicholls.stash.parameterizedbuilds.eventHandlers.RefDeletedHandler;
-import com.kylenicholls.stash.parameterizedbuilds.eventHandlers.RefHandler;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.atlassian.bitbucket.auth.AuthenticationContext;
 import com.atlassian.bitbucket.commit.CommitService;
+import com.atlassian.bitbucket.hook.repository.RepositoryHookRequest;
 import com.atlassian.bitbucket.project.Project;
 import com.atlassian.bitbucket.repository.MinimalRef;
 import com.atlassian.bitbucket.repository.RefChange;
@@ -30,199 +13,226 @@ import com.atlassian.bitbucket.setting.Settings;
 import com.atlassian.bitbucket.setting.SettingsValidationErrors;
 import com.atlassian.bitbucket.user.ApplicationUser;
 import com.kylenicholls.stash.parameterizedbuilds.ciserver.Jenkins;
+import com.kylenicholls.stash.parameterizedbuilds.eventHandlers.PushHandler;
+import com.kylenicholls.stash.parameterizedbuilds.eventHandlers.RefCreatedHandler;
+import com.kylenicholls.stash.parameterizedbuilds.eventHandlers.RefDeletedHandler;
+import com.kylenicholls.stash.parameterizedbuilds.eventHandlers.RefHandler;
 import com.kylenicholls.stash.parameterizedbuilds.helper.SettingsService;
 import com.kylenicholls.stash.parameterizedbuilds.item.Job;
 import com.kylenicholls.stash.parameterizedbuilds.item.Job.JobBuilder;
 import com.kylenicholls.stash.parameterizedbuilds.item.Server;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 public class ParameterizedBuildHookTest {
-	private final String BRANCH_REF = "refs/heads/branch";
-	private final String COMMIT = "commithash";
-	private final String REPO_SLUG = "reposlug";
-	private final String URI = "http://uri";
-	private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false);
-	private final Server projectServer = new Server("projecturl", "projectuser", "projecttoken",
-			false);
-	private RepositoryHookRequest request;
-	private Settings settings;
-	private RefChange refChange;
-	private MinimalRef minimalRef;
-	private ParameterizedBuildHook buildHook;
-	private SettingsService settingsService;
-	private Jenkins jenkins;
-	private ApplicationPropertiesService propertiesService;
-	private Repository repository;
-	private SettingsValidationErrors validationErrors;
-	private Project project;
-	private ApplicationUser user;
-	private JobBuilder jobBuilder;
-	List<Job> jobs;
+    private final String BRANCH_REF = "refs/heads/branch";
+    private final String COMMIT = "commithash";
+    private final String REPO_SLUG = "reposlug";
+    private final String URI = "http://uri";
+    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false);
+    private final Server projectServer = new Server("projecturl", "projectuser", "projecttoken",
+            false);
+    private RepositoryHookRequest request;
+    private Settings settings;
+    private RefChange refChange;
+    private MinimalRef minimalRef;
+    private ParameterizedBuildHook buildHook;
+    private SettingsService settingsService;
+    private Jenkins jenkins;
+    private ApplicationPropertiesService propertiesService;
+    private Repository repository;
+    private ExecutorService executorService;
+    private SettingsValidationErrors validationErrors;
+    private Project project;
+    private ApplicationUser user;
+    private JobBuilder jobBuilder;
+    List<Job> jobs;
 
-	@Before
-	public void setup() throws URISyntaxException {
-		settingsService = mock(SettingsService.class);
-		CommitService commitService = mock(CommitService.class);
-		jenkins = mock(Jenkins.class);
-		propertiesService = mock(ApplicationPropertiesService.class);
-		AuthenticationContext authContext = mock(AuthenticationContext.class);
+    @Before
+    public void setup() throws URISyntaxException {
+        settingsService = mock(SettingsService.class);
+        CommitService commitService = mock(CommitService.class);
+        jenkins = mock(Jenkins.class);
+        propertiesService = mock(ApplicationPropertiesService.class);
+        AuthenticationContext authContext = mock(AuthenticationContext.class);
+        executorService = mock(ExecutorService.class);
+        // executor simply invokes run on argument
+        doAnswer(invocationOnMock -> {
+            Object[] args = invocationOnMock.getArguments();
+            Runnable runnable = (Runnable) args[0];
+            runnable.run();
+            return null;
+        }).when(executorService).submit(any(Runnable.class));
 
-		request = mock(RepositoryHookRequest.class);
-		settings = mock(Settings.class);
-		refChange = mock(RefChange.class);
-		minimalRef = mock(MinimalRef.class);
-		repository = mock(Repository.class);
-		validationErrors = mock(SettingsValidationErrors.class);
-		project = mock(Project.class);
-		user = mock(ApplicationUser.class);
+        request = mock(RepositoryHookRequest.class);
+        settings = mock(Settings.class);
+        refChange = mock(RefChange.class);
+        minimalRef = mock(MinimalRef.class);
+        repository = mock(Repository.class);
+        validationErrors = mock(SettingsValidationErrors.class);
+        project = mock(Project.class);
+        user = mock(ApplicationUser.class);
 
-		when(authContext.getCurrentUser()).thenReturn(user);
-		when(request.getRepository()).thenReturn(repository);
-		when(refChange.getRef()).thenReturn(minimalRef);
-		when(refChange.getToHash()).thenReturn(COMMIT);
-		when(repository.getSlug()).thenReturn(REPO_SLUG);
-		when(repository.getProject()).thenReturn(project);
-		when(jenkins.getJenkinsServer()).thenReturn(globalServer);
-		when(jenkins.getJenkinsServer(project.getKey())).thenReturn(projectServer);
-		when(propertiesService.getBaseUrl()).thenReturn(new URI(URI));
+        when(authContext.getCurrentUser()).thenReturn(user);
+        when(request.getRepository()).thenReturn(repository);
+        when(refChange.getRef()).thenReturn(minimalRef);
+        when(refChange.getToHash()).thenReturn(COMMIT);
+        when(repository.getSlug()).thenReturn(REPO_SLUG);
+        when(repository.getProject()).thenReturn(project);
+        when(jenkins.getJenkinsServer()).thenReturn(globalServer);
+        when(jenkins.getJenkinsServer(project.getKey())).thenReturn(projectServer);
+        when(propertiesService.getBaseUrl()).thenReturn(new URI(URI));
 
-		when(minimalRef.getId()).thenReturn(BRANCH_REF);
-		jobBuilder = new Job.JobBuilder(1).jobName("").buildParameters("").branchRegex("")
-				.pathRegex("");
-		jobs = new ArrayList<>();
-		when(settingsService.getJobs(any())).thenReturn(jobs);
+        when(minimalRef.getId()).thenReturn(BRANCH_REF);
+        jobBuilder = new Job.JobBuilder(1).jobName("").buildParameters("").branchRegex("")
+                .pathRegex("");
+        jobs = new ArrayList<>();
+        when(settingsService.getJobs(any())).thenReturn(jobs);
 
-		buildHook = new ParameterizedBuildHook(settingsService, commitService, jenkins,
-				propertiesService, authContext);
-	}
+        buildHook = new ParameterizedBuildHook(settingsService, commitService, jenkins,
+                propertiesService, authContext, executorService);
+    }
 
-	@Test
-	public void testCreateHandlerADD(){
-		when(refChange.getType()).thenReturn(RefChangeType.ADD);
-		RefHandler handler = buildHook.createHandler(refChange, repository);
-		Assert.assertTrue(handler instanceof RefCreatedHandler);
-	}
+    @Test
+    public void testCreateHandlerADD() {
+        when(refChange.getType()).thenReturn(RefChangeType.ADD);
+        RefHandler handler = buildHook.createHandler(refChange, repository);
+        Assert.assertTrue(handler instanceof RefCreatedHandler);
+    }
 
-	@Test
-	public void testCreateHandlerDELETE(){
-		when(refChange.getType()).thenReturn(RefChangeType.DELETE);
-		RefHandler handler = buildHook.createHandler(refChange, repository);
-		Assert.assertTrue(handler instanceof RefDeletedHandler);
-	}
+    @Test
+    public void testCreateHandlerDELETE() {
+        when(refChange.getType()).thenReturn(RefChangeType.DELETE);
+        RefHandler handler = buildHook.createHandler(refChange, repository);
+        Assert.assertTrue(handler instanceof RefDeletedHandler);
+    }
 
-	@Test
-	public void testCreateHandlerUPDATE(){
-		when(refChange.getType()).thenReturn(RefChangeType.UPDATE);
-		RefHandler handler = buildHook.createHandler(refChange, repository);
-		Assert.assertTrue(handler instanceof PushHandler);
-	}
+    @Test
+    public void testCreateHandlerUPDATE() {
+        when(refChange.getType()).thenReturn(RefChangeType.UPDATE);
+        RefHandler handler = buildHook.createHandler(refChange, repository);
+        Assert.assertTrue(handler instanceof PushHandler);
+    }
 
-	@Test
-	public void testShowErrorIfJenkinsSettingsNull() {
-		when(jenkins.getJenkinsServer()).thenReturn(null);
-		when(jenkins.getJenkinsServer(project.getKey())).thenReturn(null);
-		buildHook.validate(settings, validationErrors, repository);
+    @Test
+    public void testShowErrorIfJenkinsSettingsNull() {
+        when(jenkins.getJenkinsServer()).thenReturn(null);
+        when(jenkins.getJenkinsServer(project.getKey())).thenReturn(null);
+        buildHook.validate(settings, validationErrors, repository);
 
-		verify(validationErrors, times(1))
-				.addFieldError("jenkins-admin-error", "Jenkins is not setup in Bitbucket Server");
-	}
+        verify(validationErrors, times(1))
+                .addFieldError("jenkins-admin-error", "Jenkins is not setup in Bitbucket Server");
+    }
 
-	@Test
-	public void testShowErrorIfBaseUrlEmpty() {
-		Server server = new Server("", null, null, false);
-		when(jenkins.getJenkinsServer()).thenReturn(server);
-		when(jenkins.getJenkinsServer(project.getKey())).thenReturn(server);
-		buildHook.validate(settings, validationErrors, repository);
+    @Test
+    public void testShowErrorIfBaseUrlEmpty() {
+        Server server = new Server("", null, null, false);
+        when(jenkins.getJenkinsServer()).thenReturn(server);
+        when(jenkins.getJenkinsServer(project.getKey())).thenReturn(server);
+        buildHook.validate(settings, validationErrors, repository);
 
-		verify(validationErrors, times(1))
-				.addFieldError("jenkins-admin-error", "Jenkins is not setup in Bitbucket Server");
-	}
+        verify(validationErrors, times(1))
+                .addFieldError("jenkins-admin-error", "Jenkins is not setup in Bitbucket Server");
+    }
 
-	@Test
-	public void testShowErrorIfJenkinsSettingsUrlEmpty() {
-		Server server = new Server("", null, null, false);
-		when(jenkins.getJenkinsServer()).thenReturn(server);
-		when(jenkins.getJenkinsServer(project.getKey())).thenReturn(null);
-		buildHook.validate(settings, validationErrors, repository);
+    @Test
+    public void testShowErrorIfJenkinsSettingsUrlEmpty() {
+        Server server = new Server("", null, null, false);
+        when(jenkins.getJenkinsServer()).thenReturn(server);
+        when(jenkins.getJenkinsServer(project.getKey())).thenReturn(null);
+        buildHook.validate(settings, validationErrors, repository);
 
-		verify(validationErrors, times(1))
-				.addFieldError("jenkins-admin-error", "Jenkins is not setup in Bitbucket Server");
-	}
+        verify(validationErrors, times(1))
+                .addFieldError("jenkins-admin-error", "Jenkins is not setup in Bitbucket Server");
+    }
 
-	@Test
-	public void testShowErrorIfProjectSettingsUrlEmpty() {
-		when(jenkins.getJenkinsServer()).thenReturn(null);
-		Server server = new Server("", null, null, false);
-		when(jenkins.getJenkinsServer(project.getKey())).thenReturn(server);
-		buildHook.validate(settings, validationErrors, repository);
+    @Test
+    public void testShowErrorIfProjectSettingsUrlEmpty() {
+        when(jenkins.getJenkinsServer()).thenReturn(null);
+        Server server = new Server("", null, null, false);
+        when(jenkins.getJenkinsServer(project.getKey())).thenReturn(server);
+        buildHook.validate(settings, validationErrors, repository);
 
-		verify(validationErrors, times(1))
-				.addFieldError("jenkins-admin-error", "Jenkins is not setup in Bitbucket Server");
-	}
+        verify(validationErrors, times(1))
+                .addFieldError("jenkins-admin-error", "Jenkins is not setup in Bitbucket Server");
+    }
 
-	@Test
-	public void testNoErrorIfOnlyJenkinsSettingsNull() {
-		when(jenkins.getJenkinsServer()).thenReturn(null);
-		Server server = new Server("baseurl", null, null, false);
-		when(jenkins.getJenkinsServer(project.getKey())).thenReturn(server);
-		buildHook.validate(settings, validationErrors, repository);
+    @Test
+    public void testNoErrorIfOnlyJenkinsSettingsNull() {
+        when(jenkins.getJenkinsServer()).thenReturn(null);
+        Server server = new Server("baseurl", null, null, false);
+        when(jenkins.getJenkinsServer(project.getKey())).thenReturn(server);
+        buildHook.validate(settings, validationErrors, repository);
 
-		verify(validationErrors, times(0)).addFieldError(any(), any());
-	}
+        verify(validationErrors, times(0)).addFieldError(any(), any());
+    }
 
-	@Test
-	public void testNoErrorIfOnlyProjectSettingsNull() {
-		Server server = new Server("baseurl", null, null, false);
-		when(jenkins.getJenkinsServer()).thenReturn(server);
-		when(jenkins.getJenkinsServer(project.getKey())).thenReturn(null);
-		buildHook.validate(settings, validationErrors, repository);
+    @Test
+    public void testNoErrorIfOnlyProjectSettingsNull() {
+        Server server = new Server("baseurl", null, null, false);
+        when(jenkins.getJenkinsServer()).thenReturn(server);
+        when(jenkins.getJenkinsServer(project.getKey())).thenReturn(null);
+        buildHook.validate(settings, validationErrors, repository);
 
-		verify(validationErrors, times(0)).addFieldError(any(), any());
-	}
+        verify(validationErrors, times(0)).addFieldError(any(), any());
+    }
 
-	@Test
-	public void testShowErrorIfJobNameEmpty() {
-		Job job = new Job.JobBuilder(1).jobName("").triggers("add".split(";")).buildParameters("")
-				.branchRegex("").pathRegex("").build();
-		jobs.add(job);
-		buildHook.validate(settings, validationErrors, repository);
+    @Test
+    public void testShowErrorIfJobNameEmpty() {
+        Job job = new Job.JobBuilder(1).jobName("").triggers("add".split(";")).buildParameters("")
+                .branchRegex("").pathRegex("").build();
+        jobs.add(job);
+        buildHook.validate(settings, validationErrors, repository);
 
-		verify(validationErrors, times(1))
-				.addFieldError(SettingsService.JOB_PREFIX + "0", "Field is required");
-	}
+        verify(validationErrors, times(1))
+                .addFieldError(SettingsService.JOB_PREFIX + "0", "Field is required");
+    }
 
-	@Test
-	public void testShowErrorIfTriggersEmpty() {
-		Job job = new Job.JobBuilder(1).jobName("name").triggers("".split(";")).buildParameters("")
-				.branchRegex("").pathRegex("").build();
-		jobs.add(job);
-		buildHook.validate(settings, validationErrors, repository);
+    @Test
+    public void testShowErrorIfTriggersEmpty() {
+        Job job = new Job.JobBuilder(1).jobName("name").triggers("".split(";")).buildParameters("")
+                .branchRegex("").pathRegex("").build();
+        jobs.add(job);
+        buildHook.validate(settings, validationErrors, repository);
 
-		verify(validationErrors, times(1)).addFieldError(SettingsService.TRIGGER_PREFIX
-				+ "0", "You must choose at least one trigger");
-	}
+        verify(validationErrors, times(1)).addFieldError(SettingsService.TRIGGER_PREFIX
+                + "0", "You must choose at least one trigger");
+    }
 
-	@Test
-	public void testShowErrorIfBranchRegexInvalid() {
-		Job job = new Job.JobBuilder(1).jobName("name").triggers("add".split(";"))
-				.buildParameters("").branchRegex("(").pathRegex("").build();
-		jobs.add(job);
-		buildHook.validate(settings, validationErrors, repository);
+    @Test
+    public void testShowErrorIfBranchRegexInvalid() {
+        Job job = new Job.JobBuilder(1).jobName("name").triggers("add".split(";"))
+                .buildParameters("").branchRegex("(").pathRegex("").build();
+        jobs.add(job);
+        buildHook.validate(settings, validationErrors, repository);
 
-		verify(validationErrors, times(1))
-				.addFieldError(SettingsService.BRANCH_PREFIX + "0", "Unclosed group");
-	}
+        verify(validationErrors, times(1))
+                .addFieldError(SettingsService.BRANCH_PREFIX + "0", "Unclosed group");
+    }
 
-	@Test
-	public void testShowErrorIfPathRegexInvalid() {
-		Job job = new Job.JobBuilder(1).jobName("name").triggers("add".split(";"))
-				.buildParameters("").branchRegex("").pathRegex("(").build();
-		jobs.add(job);
-		buildHook.validate(settings, validationErrors, repository);
+    @Test
+    public void testShowErrorIfPathRegexInvalid() {
+        Job job = new Job.JobBuilder(1).jobName("name").triggers("add".split(";"))
+                .buildParameters("").branchRegex("").pathRegex("(").build();
+        jobs.add(job);
+        buildHook.validate(settings, validationErrors, repository);
 
-		verify(validationErrors, times(1))
-				.addFieldError(SettingsService.PATH_PREFIX + "0", "Unclosed group");
-	}
+        verify(validationErrors, times(1))
+                .addFieldError(SettingsService.PATH_PREFIX + "0", "Unclosed group");
+    }
 }


### PR DESCRIPTION
ExecutorService.

Bitbucket, by default, will allocate one event processing thread per
CPU core. Bitbucket development recommends minimizing the activities
executed on the event threads.

See the following for more information:

https://github.com/Eernie/bitbucket-webhooks-plugin/issues/54