### PR TITLE
Issue 107

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
 		<bitbucket.server.version>5.4.0</bitbucket.server.version>
 		<bitbucket.data.version>5.4.0</bitbucket.data.version>
 		<atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
-		<amps.version>6.1.0</amps.version>
+		<amps.version>6.3.4</amps.version>
 		<plugin.testrunner.version>1.2.0</plugin.testrunner.version>
 	</properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>3.1.3</version>
+	<version>3.2.1</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>
@@ -267,8 +267,8 @@
 		</plugins>
 	</build>
 	<properties>
-		<bitbucket.server.version>5.1.0</bitbucket.server.version>
-		<bitbucket.data.version>5.1.0</bitbucket.data.version>
+		<bitbucket.server.version>5.4.0</bitbucket.server.version>
+		<bitbucket.data.version>5.4.0</bitbucket.data.version>
 		<atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
 		<amps.version>6.1.0</amps.version>
 		<plugin.testrunner.version>1.2.0</plugin.testrunner.version>

--- a/src/main/resources/scripts/jenkins/feature/build-dialog.js
+++ b/src/main/resources/scripts/jenkins/feature/build-dialog.js
@@ -13,62 +13,62 @@ define('trigger/build-dialog', [
     ajax,
     flag
 ) {
-	var jobs;
-	
-	function bindToDropdownLink(linkSelector, dropDownSelector, getBranchNameFunction) {
+    var jobs;
+
+    function bindToDropdownLink(linkSelector, dropDownSelector, getBranchNameFunction) {
         $(document).on('aui-dropdown2-show', dropDownSelector, function () {
-        	var $dropdownMenu = $(this);
-        	var $buildTriggerButton = $(linkSelector);
+            var $dropdownMenu = $(this);
+            var $buildTriggerButton = $(linkSelector);
             var branchInfo = getBranchNameFunction($dropdownMenu);
             var branch = branchInfo[0];
             var commit = branchInfo[1];
 
             var triggerBuildSetup = function() {
-            	var resourceUrl = getResourceUrl("getJobs") + "?branch=" + encodeURIComponent(branch) + "&commit=" + commit;
-            	
-            	jobs = getJobs(resourceUrl);
-            	if (jobs.length == 1){
-                	if (jobs[0].buildParameters.length == 0){
+                var resourceUrl = getResourceUrl("getJobs") + "?branch=" + encodeURIComponent(branch) + "&commit=" + commit;
+
+                jobs = getJobs(resourceUrl);
+                if (jobs.length == 1){
+                    if (jobs[0].buildParameters.length == 0){
                         var splitBranch = branch.split("/")
                         splitBranch.splice(0, 2) //remove ref/heads or ref/tags
                         var branchName = splitBranch.join("%2F")
-                		var buildUrl = getResourceUrl("triggerBuild/0/") + encodeURIComponent(branchName);
-                		triggerBuild(buildUrl, branch);
-                    	return false;
-                	}
-            	}
-        		var buildUrl = getResourceUrl("triggerBuild");
-            	showManualBuildDialog(buildUrl, branch);
-            	return false;
+                        var buildUrl = getResourceUrl("triggerBuild/0/") + encodeURIComponent(branchName);
+                        triggerBuild(buildUrl, branch);
+                        return false;
+                    }
+                }
+                var buildUrl = getResourceUrl("triggerBuild");
+                showManualBuildDialog(buildUrl, branch);
+                return false;
             };
             
             $buildTriggerButton.on('click', triggerBuildSetup);
             $dropdownMenu.on('aui-dropdown2-hide', function() {
-            	$buildTriggerButton.off('click', triggerBuildSetup);
+                $buildTriggerButton.off('click', triggerBuildSetup);
             });
             return false;
         });
     }
     
-	function getResourceUrl(resourceType){
-		return _aui.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().getKey() + '/repos/'
+    function getResourceUrl(resourceType){
+        return _aui.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().getKey() + '/repos/'
         + pageState.getRepository().getSlug() + '/' + resourceType;
-	}
+    }
     
-	function getJobs(resourceUrl){
-		var results;
-		$.ajax({
-		  type: "GET",
-		  url: resourceUrl,
-		  dataType: 'json',
-		  async: false,
-		  success: function (data){
-			  results = data;
-		  }
-		});
-		return results;
-	}
-	
+    function getJobs(resourceUrl){
+        var results;
+        $.ajax({
+          type: "GET",
+          url: resourceUrl,
+          dataType: 'json',
+          async: false,
+          success: function (data){
+              results = data;
+          }
+        });
+        return results;
+    }
+
     function showManualBuildDialog(buildUrl, branch) {
         var dialog = _aui.dialog2(aui.dialog.dialog2({
             titleText: AJS.I18n.getText('Build with Parameters'),
@@ -86,134 +86,134 @@ define('trigger/build-dialog', [
         dialog.$el.find('form').on('submit', function(e) { e.preventDefault(); });
         dialog.$el.find('#start-build').on('click', function() {
             _.defer(function() {
-            	var $jobParameters = dialog.$el.find('.jenkins-form');
-            	var jobSelect = document.getElementById("job");
+                var $jobParameters = dialog.$el.find('.jenkins-form');
+                var jobSelect = document.getElementById("job");
                 var id = jobSelector.options[jobSelector.selectedIndex].value;
                 var splitBranch = branch.split("/")
                 splitBranch.splice(0, 2) //remove ref/heads or ref/tags
                 var branchName = splitBranch.join("%2F")
-            	buildUrl += "/" + jobs[id].id + "/" + encodeURIComponent(branchName) + "?";
-            	$jobParameters.each(function(index, jobParam) {
-            		var $curJobParam = $(jobParam);
-            		var key = $curJobParam.find('label').text();
-            		var value = dialog.$el.find('#build-param-value-' + index).val();
-            		var type = $(dialog.$el.find('#build-param-value-' + index)[0]).attr('class');
-            		if (type.indexOf("checkbox") > -1) {
-            			value = dialog.$el.find('#build-param-value-' + index)[0].checked;
-            		} else if (type.indexOf("hidden") > -1) {
-            			value = value.replace('refs/heads/','');
-					}
-            		buildUrl += key + "=" + encodeURIComponent(value) + "&";
-            	});
-            	triggerBuild(buildUrl.slice(0,-1));
+                buildUrl += "/" + jobs[id].id + "/" + encodeURIComponent(branchName) + "?";
+                $jobParameters.each(function(index, jobParam) {
+                    var $curJobParam = $(jobParam);
+                    var key = $curJobParam.find('label').text();
+                    var value = dialog.$el.find('#build-param-value-' + index).val();
+                    var type = $(dialog.$el.find('#build-param-value-' + index)[0]).attr('class');
+                    if (type.indexOf("checkbox") > -1) {
+                        value = dialog.$el.find('#build-param-value-' + index)[0].checked;
+                    } else if (type.indexOf("hidden") > -1) {
+                        value = value.replace('refs/heads/','');
+                    }
+                    buildUrl += key + "=" + encodeURIComponent(value) + "&";
+                });
+                triggerBuild(buildUrl.slice(0,-1));
                 dialog.hide();
             });
         }).focus().select();
     }
-	
-	$(document).on('change', '#job', function(e) {
-    	e.preventDefault();
-    	setupJobForm(jobs[this.value]);
+
+    $(document).on('change', '#job', function(e) {
+        e.preventDefault();
+        setupJobForm(jobs[this.value]);
     });
-	
-	function setupJobForm(job) {
-		var $container = $('.job-params');
-		
-		var html = '<div class="job-params">';
-		var parameters = job.buildParameters;
-		if (parameters) {
-			for (i = 0; i < parameters.length; i++) {
-				var keyValue = parameters[i];
-				for (var key in keyValue){
-					var value = keyValue[key];
-					if (typeof value === "boolean") {
-						html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addBooleanParameter({
-				            count: i,
-				            key: key,
-				            value: value
-				        });
-					} else if (typeof value === 'string') {
-					    if (value.startsWith('refs/heads/')) {
-					        html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addBranchParameter({
-                        		count: i,
-                        		key: key,
-                        		value: value
-                        	});
-					    } else {
-						    html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addStringParameter({
-				                count: i,
-				                key: key,
-				                value: value
-				            });
-				        }
-					} else {
-						html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addArrayParameter({
-				            count: i,
-				            key: key,
-				            value: value
-				        });
-					}
-				}
-			}
-		}
-		$container.replaceWith(html + "</div>");
-	}
-	
-	function triggerBuild(buildUrl){
-		var successFlag = flag({
+
+    function setupJobForm(job) {
+        var $container = $('.job-params');
+
+        var html = '<div class="job-params">';
+        var parameters = job.buildParameters;
+        if (parameters) {
+            for (i = 0; i < parameters.length; i++) {
+                var keyValue = parameters[i];
+                for (var key in keyValue){
+                    var value = keyValue[key];
+                    if (typeof value === "boolean") {
+                        html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addBooleanParameter({
+                            count: i,
+                            key: key,
+                            value: value
+                        });
+                    } else if (typeof value === 'string') {
+                        if (value.startsWith('refs/heads/')) {
+                            html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addBranchParameter({
+                                count: i,
+                                key: key,
+                                value: value
+                            });
+                        } else {
+                            html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addStringParameter({
+                                count: i,
+                                key: key,
+                                value: value
+                            });
+                        }
+                    } else {
+                        html += com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.addArrayParameter({
+                            count: i,
+                            key: key,
+                            value: value
+                        });
+                    }
+                }
+            }
+        }
+        $container.replaceWith(html + "</div>");
+    }
+
+    function triggerBuild(buildUrl){
+        var successFlag = flag({
             type: 'success',
             body: 'Build started',
             close: 'auto'
         });
-		ajax.rest({
-		  type: "POST",
-		  url: buildUrl,
-		  dataType: 'json',
-		  async: true
-		}).success(function (data) {
-    		if (data.error){
-    			successFlag.close();
-    			flag({
+        ajax.rest({
+          type: "POST",
+          url: buildUrl,
+          dataType: 'json',
+          async: true
+        }).success(function (data) {
+            if (data.error){
+                successFlag.close();
+                flag({
                     type: 'warning',
                     body: data.messageText,
                     close: 'auto'
                 });
-    		} else if (data.prompt) {
-    			var promptCookie = getCookie("jenkinsPrompt");
-    			var settingsPath = _aui.contextPath() + "/plugins/servlet/account/jenkins";
-    			if (promptCookie !== "ignore") {
-	    			flag({
-	                    type: 'info',
-	                    body: '<p>Optional: <a href="' + settingsPath + 
-	                    '" target="_blank">You can link your Jenkins account to your Bitbucket account.</a></p>' + 
-	                    '<br/><label><input id="prompt-cookie" type="checkbox" /><span>Don\'t show again</span></label>'
-	                });
-    			}
-    		}
-		});
-	};
-	
-	$(document).on('change', '#prompt-cookie', function(e) {
-		var d = new Date();
-	    d.setTime(d.getTime() + (365*24*60*60*1000));
-	    var expires = "expires="+ d.toUTCString();
-		document.cookie = "jenkinsPrompt=ignore;" + expires + ";path=/";
+            } else if (data.prompt) {
+                var promptCookie = getCookie("jenkinsPrompt");
+                var settingsPath = _aui.contextPath() + "/plugins/servlet/account/jenkins";
+                if (promptCookie !== "ignore") {
+                    flag({
+                        type: 'info',
+                        body: '<p>Optional: <a href="' + settingsPath +
+                        '" target="_blank">You can link your Jenkins account to your Bitbucket account.</a></p>' +
+                        '<br/><label><input id="prompt-cookie" type="checkbox" /><span>Don\'t show again</span></label>'
+                    });
+                }
+            }
+        });
+    };
+
+    $(document).on('change', '#prompt-cookie', function(e) {
+        var d = new Date();
+        d.setTime(d.getTime() + (365*24*60*60*1000));
+        var expires = "expires="+ d.toUTCString();
+        document.cookie = "jenkinsPrompt=ignore;" + expires + ";path=/";
     });
-	
-	function getCookie(cname) {
-	    var name = cname + "=";
-	    var ca = document.cookie.split(';');
-	    for(var i = 0; i <ca.length; i++) {
-	        var c = ca[i];
-	        while (c.charAt(0)==' ') {
-	            c = c.substring(1);
-	        }
-	        if (c.indexOf(name) == 0) {
-	            return c.substring(name.length,c.length);
-	        }
-	    }
-	    return "";
-	}
-	
+
+    function getCookie(cname) {
+        var name = cname + "=";
+        var ca = document.cookie.split(';');
+        for(var i = 0; i <ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0)==' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) == 0) {
+                return c.substring(name.length,c.length);
+            }
+        }
+        return "";
+    }
+
     exports.bindToDropdownLink = bindToDropdownLink;
 });

--- a/src/main/resources/scripts/jenkins/feature/build-dialog.js
+++ b/src/main/resources/scripts/jenkins/feature/build-dialog.js
@@ -29,7 +29,9 @@ define('trigger/build-dialog', [
             	jobs = getJobs(resourceUrl);
             	if (jobs.length == 1){
                 	if (jobs[0].buildParameters.length == 0){
-                	    branchName = branch.split("/").pop()
+                        var splitBranch = branch.split("/")
+                        splitBranch.splice(0, 2) //remove ref/heads or ref/tags
+                        var branchName = splitBranch.join("%2F")
                 		var buildUrl = getResourceUrl("triggerBuild/0/") + encodeURIComponent(branchName);
                 		triggerBuild(buildUrl, branch);
                     	return false;
@@ -87,7 +89,9 @@ define('trigger/build-dialog', [
             	var $jobParameters = dialog.$el.find('.jenkins-form');
             	var jobSelect = document.getElementById("job");
                 var id = jobSelector.options[jobSelector.selectedIndex].value;
-                branchName = branch.split("/").pop()
+                var splitBranch = branch.split("/")
+                splitBranch.splice(0, 2) //remove ref/heads or ref/tags
+                var branchName = splitBranch.join("%2F")
             	buildUrl += "/" + jobs[id].id + "/" + encodeURIComponent(branchName) + "?";
             	$jobParameters.each(function(index, jobParam) {
             		var $curJobParam = $(jobParam);

--- a/src/main/resources/scripts/jenkins/feature/build-dialog.soy
+++ b/src/main/resources/scripts/jenkins/feature/build-dialog.soy
@@ -5,19 +5,19 @@
  */
 {template .buildDialog}
     {call aui.form.form}
-    	{param action: '' /}
+        {param action: '' /}
         {param content}
-	    <select class="select" id="job" name="job" style="max-width:initial;width:auto">
-	        {for $i in range(length($jobs))}
-            	<option value="{$i}">{$jobs[$i]['jobName']}</option>
+        <select class="select" id="job" name="job" style="max-width:initial;width:auto">
+            {for $i in range(length($jobs))}
+                <option value="{$i}">{$jobs[$i]['jobName']}</option>
             {/for}
-	    </select>
-	    {call aui.form.form}
-        	{param content}
-        		<div class="job-params" />
-    		{/param}
-    		{param action: ''/}
-		{/call}
+        </select>
+        {call aui.form.form}
+            {param content}
+                <div class="job-params" />
+            {/param}
+            {param action: ''/}
+        {/call}
         {/param}
     {/call}
 {/template}
@@ -29,16 +29,16 @@
  */
 {template .addStringParameter}
     <div id="jenkins-form-{$count}" class="field-group jenkins-form">
-	    {call aui.form.label}
-	         {param forField : 'build-param-value-' + $count /}
-	         {param content : $key /}
-	    {/call}
-	    <input class="text" 
-			id="build-param-value-{$count}"
-			type="text" 
-			name="build-param-value-{$count}"
-			value="{$value}">
-	</div>
+        {call aui.form.label}
+             {param forField : 'build-param-value-' + $count /}
+             {param content : $key /}
+        {/call}
+        <input class="text"
+            id="build-param-value-{$count}"
+            type="text"
+            name="build-param-value-{$count}"
+            value="{$value}">
+    </div>
 {/template}
 
 /**
@@ -48,12 +48,12 @@
  */
 {template .addBranchParameter}
     <div id="jenkins-form-{$count}" class="jenkins-form">
-		{call bitbucket.component.branchSelector.field}
-			{param id: 'build-param-value-' + $count /}
-			{param labelText: $key /}
-			{param initialValue: $value /}
-		{/call}
-	</div>
+        {call bitbucket.component.branchSelector.field}
+            {param id: 'build-param-value-' + $count /}
+            {param labelText: $key /}
+            {param initialValue: $value /}
+        {/call}
+    </div>
 {/template}
 
 /**
@@ -63,12 +63,12 @@
  */
 {template .addBooleanParameter}
     <div id="jenkins-form-{$count}" class="field-group jenkins-form">
-	    <div class="checkbox">
-			<input class="checkbox" type="checkbox" id="build-param-value-{$count}" name="build-param-value-{$count}" 
-				{$value == 'true' ? 'checked="checked"' : ''}>
-			<label for="build-param-value-2">{$key}</label>
-		</div>
-	</div>
+        <div class="checkbox">
+            <input class="checkbox" type="checkbox" id="build-param-value-{$count}" name="build-param-value-{$count}"
+                {$value == 'true' ? 'checked="checked"' : ''}>
+            <label for="build-param-value-2">{$key}</label>
+        </div>
+    </div>
 {/template}
 
 /**
@@ -78,15 +78,15 @@
  */
 {template .addArrayParameter}
     <div id="jenkins-form-{$count}" class="field-group jenkins-form">
-		{call aui.form.label}
-		     {param forField : 'build-param-value-' + $count /}
-		     {param content : $key /}
-		{/call}
-		<select class="select" id="build-param-value-{$count}">
-			{foreach $selectValue in $value}
-		    	<option value="{$selectValue}">{$selectValue}</option>
-		    {/foreach}
-		</select>
+        {call aui.form.label}
+             {param forField : 'build-param-value-' + $count /}
+             {param content : $key /}
+        {/call}
+        <select class="select" id="build-param-value-{$count}">
+            {foreach $selectValue in $value}
+                <option value="{$selectValue}">{$selectValue}</option>
+            {/foreach}
+        </select>
     </div>
 {/template}
 
@@ -94,9 +94,9 @@
  * Start build button
  */
 {template .buildButton}
-	{call widget.aui.form.button}
-	    {param id: 'start-build' /}
-	    {param label: 'Start Build' /}
-	    {param autofocus: true /}
-	{/call}
+    {call widget.aui.form.button}
+        {param id: 'start-build' /}
+        {param label: 'Start Build' /}
+        {param autofocus: true /}
+    {/call}
 {/template}

--- a/src/main/resources/scripts/jenkins/pb-pr-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-pr-trigger.js
@@ -24,7 +24,9 @@ define('jenkins/parameterized-build-pullrequest', [
         jobs = getJobs(resourceUrl);
         if (jobs.length == 1){
             if (jobs[0].buildParameters.length == 0){
-                branchName = branch.split("/").pop()
+                var splitBranch = branch.split("/")
+                splitBranch.splice(0, 2) //remove ref/heads or ref/tags
+                var branchName = splitBranch.join("%2F")
                 var buildUrl = getResourceUrl("triggerBuild/0/" + encodeURIComponent(branchName));
                 triggerBuild(buildUrl);
                 return false;
@@ -74,7 +76,9 @@ define('jenkins/parameterized-build-pullrequest', [
                 var $jobParameters = dialog.$el.find('.jenkins-form');
                 var jobSelect = document.getElementById("job");
                 var id = jobSelector.options[jobSelector.selectedIndex].value;
-                branchName = branch.split("/").pop()
+                var splitBranch = branch.split("/")
+                splitBranch.splice(0, 2) //remove ref/heads or ref/tags
+                var branchName = splitBranch.join("%2F")
                 buildUrl += "/" + jobs[id].id + "/" + encodeURIComponent(branchName) + "?";
                 $jobParameters.each(function(index, jobParam) {
                     var $curJobParam = $(jobParam);


### PR DESCRIPTION
This PR fixes a bug preventing jenkins builds from occuring if:
 - the trigger is a manual trigger;
 - the job is a multibranch pipeline; and
 - the branch name involves a forward slash "/"

This bug was brought up in Issue #107.

The only real code change is switching all occurrences of `branch.split("/").pop()` to 
```
var splitBranch = branch.split("/")
splitBranch.splice(0, 2) //remove ref/heads or ref/tags
var branchName = splitBranch.join("%2F")
```
The code was originally intended to strip the ref/heads or ref/tags prefix from a branch name but unintentionally stripped too much. Now it should only remove what is intended and sanitize "/" values.

The rest of the PR was just whitespace conversion because the mixed tabs/spaces in the javascript was annoying me.