### PR TITLE
ISSUE-113 jobs not displaying in repo settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>3.2.2</version>
+	<version>3.2.3</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>

--- a/src/main/resources/static/parameterized-build-hook.soy
+++ b/src/main/resources/static/parameterized-build-hook.soy
@@ -36,7 +36,7 @@
                 <div class="field-group"><div class="error">{$errors['jenkins-admin-error']}</div></div>
         {/if}
         {let $configKeys: $config ? keys($config) : [] /}
-        {let $visibleInputsCount: $configKeys.length > 0 ? ($configKeys.length / 10) : 1 /}
+        {let $visibleInputsCount: $configKeys.length > 0 ? ($configKeys.length / 9) : 1 /}
         {for $i in range($visibleInputsCount)}
             {call .addJob}
                 {param canDelete: $visibleInputsCount > 1 /}


### PR DESCRIPTION
Apparently, I can't count.

The soy template uses the expected number of fields of all combined jobs to determine how many jobs to display. Each job has 9 fields but the soy was expecting 10. Luckily, soy rounds up so everything works as expected until a repo hits 10 jobs. This results in the json containing 90 fields so we expect 9 jobs to exist. The next time the soy is loaded, the last job is not loaded so saving the jobs again will actually delete the 10th job. #112  brings this issue to light.

This PR re-aligns the number of fields in a job with the expected number. If possible the json payload should probably be shifted towards a nested structure so this sort of bug doesn't happen again. It would also put us in a better spot for #105 since it would be much easier to add or remove jobs.