### PR TITLE
'bufix/jenkins path missing on csrf'

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
@@ -111,14 +111,14 @@ public class ParameterizedBuildHook
 						.getDescription());
 			}
 
-			PatternSyntaxException pathExecption = null;
+			PatternSyntaxException pathException = null;
 			try {
 				Pattern.compile(job.getPathRegex());
 			} catch (PatternSyntaxException e) {
-				pathExecption = e;
+				pathException = e;
 			}
-			if (pathExecption != null) {
-				errors.addFieldError(SettingsService.PATH_PREFIX + i, pathExecption
+			if (pathException != null) {
+				errors.addFieldError(SettingsService.PATH_PREFIX + i, pathException
 						.getDescription());
 			}
 		}

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
@@ -100,14 +100,14 @@ public class ParameterizedBuildHook
 						+ i, "You must choose at least one trigger");
 			}
 
-			PatternSyntaxException branchExecption = null;
+			PatternSyntaxException branchException = null;
 			try {
 				Pattern.compile(job.getBranchRegex());
 			} catch (PatternSyntaxException e) {
-				branchExecption = e;
+				branchException = e;
 			}
-			if (branchExecption != null) {
-				errors.addFieldError(SettingsService.BRANCH_PREFIX + i, branchExecption
+			if (branchException != null) {
+				errors.addFieldError(SettingsService.BRANCH_PREFIX + i, branchException
 						.getDescription());
 			}
 

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/AccountServer.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/AccountServer.java
@@ -53,4 +53,17 @@ public class AccountServer extends CIServer {
         }};
         return ImmutableMap.copyOf(baseMap);
     }
+
+    public String toString(){
+        List<UserToken> projectTokens = jenkins
+                .getAllUserTokens(user, projectService.findAllKeys(), projectService);
+        String result = "";
+        result += "user: "+user+", ";
+        result += "projectTokens: "+projectTokens+", { ";
+        for (String param:parameters.keySet()){
+            result+= "param: "+param+", value: "+parameters.get(param) + ", ";
+        }
+        result += " }";
+        return result;
+    }
 }

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/AccountServer.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/AccountServer.java
@@ -53,17 +53,4 @@ public class AccountServer extends CIServer {
         }};
         return ImmutableMap.copyOf(baseMap);
     }
-
-    public String toString(){
-        List<UserToken> projectTokens = jenkins
-                .getAllUserTokens(user, projectService.findAllKeys(), projectService);
-        String result = "";
-        result += "user: "+user+", ";
-        result += "projectTokens: "+projectTokens+", { ";
-        for (String param:parameters.keySet()){
-            result+= "param: "+param+", value: "+parameters.get(param) + ", ";
-        }
-        result += " }";
-        return result;
-    }
 }

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServerFactory.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServerFactory.java
@@ -41,7 +41,14 @@ public class CIServerFactory {
     private static Server getServerFromMap(Map<String, String[]> parameters) {
         boolean jenkinsAltUrl = parameters.get("jenkinsAltUrl") != null
                 && "on".equals(parameters.get("jenkinsAltUrl")[0]) ? true : false;
+        boolean jenkinsCSRF = false;
+        try {
+            jenkinsCSRF = parameters.get("jenkinsCSRF") != null
+                    && "on".equals(parameters.get("jenkinsCSRF")[0]) ? true : false;
+        } catch (Exception e) {
+            // nothing to do here, this is for initialization purpose
+        }
         return new Server(parameters.get("jenkinsUrl")[0], parameters.get("jenkinsUser")[0],
-                parameters.get("jenkinsToken")[0], jenkinsAltUrl);
+                parameters.get("jenkinsToken")[0], jenkinsAltUrl, jenkinsCSRF );
     }
 }

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServlet.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServlet.java
@@ -61,23 +61,25 @@ public class CIServlet extends HttpServlet {
 			CIServer ciServer = CIServerFactory.getServer(pathInfo, jenkins, req.getParameterMap(),
 					authContext.getCurrentUser(), projectService);
 
-			// optout that part if on account info (no submit or clear-settings stuff)
-			if (!pathInfo.equals("/jenkins/account")) {
-
-				if (req.getParameter("submit").equals("Test Jenkins Settings")) 
-					render(res, ciServer.JENKINS_SETTINGS, ciServer.testSettings());
-				} else {
-					boolean clearSettings = req.getParameter("clear-settings") != null
-							&& "on".equals(req.getParameter("clear-settings"));
-					Map<String, Object> renderLoc = ciServer.postSettings(clearSettings);
-					if (renderLoc != null) {
-						render(res, ciServer.JENKINS_SETTINGS, renderLoc);
-					} else {
-						doGet(req, res);
-					}
+			Map<String,String[]> parameters = req.getParameterMap();
+			for (String parameter:parameters.keySet()){
+				logger.debug("doPost: parameter "+parameter+ " contains values:");
+				for(String value:parameters.get(parameter)){
+					logger.debug(" - \""+value+"\"");
 				}
-			}else {
-				doGet(req, res);
+			}
+
+			if (req.getParameter("submit").equals("Test Jenkins Settings")) {
+				render(res, ciServer.JENKINS_SETTINGS, ciServer.testSettings());
+			} else {
+				boolean clearSettings = req.getParameter("clear-settings") != null
+						&& "on".equals(req.getParameter("clear-settings"));
+				Map<String, Object> renderLoc = ciServer.postSettings(clearSettings);
+				if (renderLoc != null) {
+					render(res, ciServer.JENKINS_SETTINGS, renderLoc);
+				} else {
+					doGet(req, res);
+				}
 			}
 		} catch (Exception e) {
 			logger.error("Exception in CIServlet.doPost: " + e.getMessage(), e);

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServlet.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServlet.java
@@ -61,17 +61,23 @@ public class CIServlet extends HttpServlet {
 			CIServer ciServer = CIServerFactory.getServer(pathInfo, jenkins, req.getParameterMap(),
 					authContext.getCurrentUser(), projectService);
 
-			if (req.getParameter("submit").equals("Test Jenkins Settings")) {
-				render(res, ciServer.JENKINS_SETTINGS, ciServer.testSettings());
-			} else {
-				boolean clearSettings = req.getParameter("clear-settings") != null
-						&& "on".equals(req.getParameter("clear-settings"));
-				Map<String, Object> renderLoc = ciServer.postSettings(clearSettings);
-				if (renderLoc != null){
-					render(res, ciServer.JENKINS_SETTINGS, renderLoc);
+			// optout that part if on account info (no submit or clear-settings stuff)
+			if (!pathInfo.equals("/jenkins/account")) {
+
+				if (req.getParameter("submit").equals("Test Jenkins Settings")) 
+					render(res, ciServer.JENKINS_SETTINGS, ciServer.testSettings());
 				} else {
-					doGet(req, res);
+					boolean clearSettings = req.getParameter("clear-settings") != null
+							&& "on".equals(req.getParameter("clear-settings"));
+					Map<String, Object> renderLoc = ciServer.postSettings(clearSettings);
+					if (renderLoc != null) {
+						render(res, ciServer.JENKINS_SETTINGS, renderLoc);
+					} else {
+						doGet(req, res);
+					}
 				}
+			}else {
+				doGet(req, res);
 			}
 		} catch (Exception e) {
 			logger.error("Exception in CIServlet.doPost: " + e.getMessage(), e);

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
@@ -214,7 +214,6 @@ public class Jenkins {
 	 * that have a Jenkins server set.
 	 *
 	 * @return a list of all user tokens for all projects (including global)
-	 * @return a list of all user tokens for all projects (including global)
 	 *         that have a Jenkins server set.
 	 * @param user
 	 *            the user to get the token for

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/Jenkins.java
@@ -116,7 +116,8 @@ public class Jenkins {
 			// legacy settings
 			String[] serverProps = settingObj.toString().split(";");
 			boolean altUrl = serverProps.length > 3 && "true".equals(serverProps[3]) ? true : false;
-			return new Server(serverProps[0], serverProps[1], serverProps[2], altUrl);
+			boolean csrfEnabled = (serverProps.length > 4 && "true".equals(serverProps[4])) ? true : false;
+			return new Server(serverProps[0], serverProps[1], serverProps[2], altUrl, csrfEnabled);
 		}
 		return null;
 	}
@@ -213,6 +214,7 @@ public class Jenkins {
 	 * that have a Jenkins server set.
 	 *
 	 * @return a list of all user tokens for all projects (including global)
+	 * @return a list of all user tokens for all projects (including global)
 	 *         that have a Jenkins server set.
 	 * @param user
 	 *            the user to get the token for
@@ -253,17 +255,19 @@ public class Jenkins {
 	 *            the build url to trigger
 	 * @param joinedToken
 	 *            the authentication token to use in the request
+     * @param csrfToken
+     *            the token to use in case cross site protection is enabled
 	 * @param promptUser
 	 *            prompt the user to link their jenkins account
 	 */
 	public JenkinsResponse sanitizeTrigger(@Nullable String buildUrl, @Nullable String joinedToken,
-			boolean promptUser) {
+			@Nullable String csrfHeader, boolean promptUser) {
 		if (buildUrl == null) {
 			return new JenkinsResponse.JenkinsMessage().error(true)
 					.messageText("Jenkins settings are not setup").build();
 		}
 
-		return httpPost(buildUrl.replace(" ", "%20"), joinedToken, promptUser);
+		return httpPost(buildUrl.replace(" ", "%20"), joinedToken, csrfHeader, promptUser);
 	}
 
 	public JenkinsResponse triggerJob(String projectKey, ApplicationUser user, Job job, BitbucketVariables bitbucketVariables) {
@@ -287,7 +291,18 @@ public class Jenkins {
 			}
 		}
 
-		return sanitizeTrigger(buildUrl, joinedUserToken, prompt);
+        String csrfHeader = null;
+        if (jenkinsServer.getCsrfEnabled()) {
+            // get a CSRF token because cross site protection is enabled
+            try {
+                logger.debug("get csrf header with token: "+joinedUserToken);
+                csrfHeader = getCrumb(jenkinsServer.getBaseUrl(), joinedUserToken);
+            } catch(Exception e){
+                logger.warn("error getting CSRF token");
+            }
+        }
+
+		return sanitizeTrigger(buildUrl, joinedUserToken, csrfHeader, prompt);
 	}
 
 	private HttpURLConnection setupConnection(String baseUrl, String userToken) throws Exception{
@@ -311,6 +326,23 @@ public class Jenkins {
 			HttpURLConnection connection = setupConnection(url, server.getJoinedToken());
 			connection.setRequestMethod("GET");
 			connection.setFixedLengthStreamingMode(0);
+
+			String csrfHeader = null;
+			if (server.getCsrfEnabled()) {
+				// get a CSRF token because cross site protection is enabled
+				try {
+					logger.debug("get csrf header with token: "+server.getJoinedToken());
+					csrfHeader = getCrumb(server.getBaseUrl(), server.getJoinedToken());
+				} catch(Exception e){
+					logger.warn("error getting CSRF token");
+				}
+			}
+
+			if (csrfHeader != null){
+				String[] header = csrfHeader.split(":");
+				connection.setRequestProperty(header[0], header[1]);
+			}
+
 			connection.connect();
 
 			int status = connection.getResponseCode();
@@ -326,11 +358,8 @@ public class Jenkins {
 		}
 	}
 
-	private String getCrumb(String buildUrl, String token) throws Exception{
-		URL url = new URL(buildUrl);
-		String port = url.getPort() == -1 ? "" : ":" + Integer.toString(url.getPort());
-		String jenkins_url = url.getProtocol() + "://" + url.getHost() + port;
-		String crumbUrl = jenkins_url  + "/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)";
+	private String getCrumb(String baseUrl, String token) throws Exception{
+		String crumbUrl = baseUrl  + "/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)";
 		HttpURLConnection connection = setupConnection(crumbUrl, token);
 		connection.connect();
 		int status = connection.getResponseCode();
@@ -341,16 +370,15 @@ public class Jenkins {
 		}
 	}
 
-	private JenkinsResponse httpPost(String buildUrl, String token, boolean prompt) {
+	private JenkinsResponse httpPost(String buildUrl, String token, String csrfHeader, boolean prompt) {
 		JenkinsMessage jenkinsMessage = new JenkinsResponse.JenkinsMessage().prompt(prompt);
 		try {
 			HttpURLConnection connection = setupConnection(buildUrl, token);
 			connection.setRequestMethod("POST");
 			connection.setFixedLengthStreamingMode(0);
 
-			String crumb = getCrumb(buildUrl, token);
-			if (crumb != null){
-				String[] header = crumb.split(":");
+			if (csrfHeader != null){
+				String[] header = csrfHeader.split(":");
 				connection.setRequestProperty(header[0], header[1]);
 			}
 			connection.connect();

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Server.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Server.java
@@ -8,12 +8,14 @@ public class Server {
 	private String user;
 	private String token;
 	private boolean altUrl;
+	private boolean csrfEnabled;
 
-	public Server(String baseUrl, String user, String token, boolean altUrl) {
+	public Server(String baseUrl, String user, String token, boolean altUrl, boolean csrfEnabled) {
 		this.baseUrl = baseUrl;
 		this.user = user;
 		this.token = token;
 		this.altUrl = altUrl;
+		this.csrfEnabled = csrfEnabled;
 	}
 
 	public Server(Map<String, Object> map) {
@@ -21,6 +23,11 @@ public class Server {
 		this.user = (String) map.get("user");
 		this.token = (String) map.get("token");
 		this.altUrl = Boolean.parseBoolean(map.get("altUrl").toString());
+		try {
+			this.csrfEnabled = Boolean.parseBoolean(map.get("csrfEnabled").toString());
+		}catch(Exception e){
+			this.csrfEnabled = false;
+		}
 	}
 
 	public String getBaseUrl() {
@@ -38,6 +45,10 @@ public class Server {
 		return token;
 	}
 
+	public boolean getCsrfEnabled() {
+		return csrfEnabled;
+	}
+
 	public boolean getAltUrl() {
 		return altUrl;
 	}
@@ -48,6 +59,7 @@ public class Server {
 		map.put("user", user);
 		map.put("token", token);
 		map.put("altUrl", altUrl);
+		map.put("csrfEnabled", csrfEnabled);
 		return map;
 	}
 

--- a/src/main/resources/templates/jenkins-admin-settings.soy
+++ b/src/main/resources/templates/jenkins-admin-settings.soy
@@ -115,6 +115,11 @@
     	{param labelContent: 'Build Token Root Plugin (uses an alternate url for triggering builds)' /}
     {/call}
     {call widget.aui.form.checkbox}
+        {param id:'jenkinsCSRF' /}
+        {param checked: $server.csrfEnabled /}
+        {param labelContent: 'Check this box if your Jenkins instance has the CSRF protection enabled' /}
+    {/call}
+    {call widget.aui.form.checkbox}
     	{param id:'clear-settings' /}
     	{param labelContent: 'Clear Settings' /}
     {/call}

--- a/src/main/resources/templates/jenkins-user-settings.soy
+++ b/src/main/resources/templates/jenkins-user-settings.soy
@@ -31,6 +31,7 @@
 					{param id: 'submit' /}
 					{param text: 'Save' /}
 					{param type: 'submit' /}
+                    {param name: 'submit' /}
 					{param extraClasses: 'aui-button-primary' /}
 			    {/call}
 			{/if}

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHookTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHookTest.java
@@ -44,9 +44,9 @@ public class ParameterizedBuildHookTest {
     private final String COMMIT = "commithash";
     private final String REPO_SLUG = "reposlug";
     private final String URI = "http://uri";
-    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false);
+    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false, false);
     private final Server projectServer = new Server("projecturl", "projectuser", "projecttoken",
-            false);
+            false, false);
     private RepositoryHookRequest request;
     private Settings settings;
     private RefChange refChange;
@@ -141,7 +141,7 @@ public class ParameterizedBuildHookTest {
 
     @Test
     public void testShowErrorIfBaseUrlEmpty() {
-        Server server = new Server("", null, null, false);
+        Server server = new Server("", null, null, false, false);
         when(jenkins.getJenkinsServer()).thenReturn(server);
         when(jenkins.getJenkinsServer(project.getKey())).thenReturn(server);
         buildHook.validate(settings, validationErrors, repository);
@@ -152,7 +152,7 @@ public class ParameterizedBuildHookTest {
 
     @Test
     public void testShowErrorIfJenkinsSettingsUrlEmpty() {
-        Server server = new Server("", null, null, false);
+        Server server = new Server("", null, null, false, false);
         when(jenkins.getJenkinsServer()).thenReturn(server);
         when(jenkins.getJenkinsServer(project.getKey())).thenReturn(null);
         buildHook.validate(settings, validationErrors, repository);
@@ -164,7 +164,7 @@ public class ParameterizedBuildHookTest {
     @Test
     public void testShowErrorIfProjectSettingsUrlEmpty() {
         when(jenkins.getJenkinsServer()).thenReturn(null);
-        Server server = new Server("", null, null, false);
+        Server server = new Server("", null, null, false, false);
         when(jenkins.getJenkinsServer(project.getKey())).thenReturn(server);
         buildHook.validate(settings, validationErrors, repository);
 
@@ -175,7 +175,7 @@ public class ParameterizedBuildHookTest {
     @Test
     public void testNoErrorIfOnlyJenkinsSettingsNull() {
         when(jenkins.getJenkinsServer()).thenReturn(null);
-        Server server = new Server("baseurl", null, null, false);
+        Server server = new Server("baseurl", null, null, false, false);
         when(jenkins.getJenkinsServer(project.getKey())).thenReturn(server);
         buildHook.validate(settings, validationErrors, repository);
 
@@ -184,7 +184,7 @@ public class ParameterizedBuildHookTest {
 
     @Test
     public void testNoErrorIfOnlyProjectSettingsNull() {
-        Server server = new Server("baseurl", null, null, false);
+        Server server = new Server("baseurl", null, null, false, false);
         when(jenkins.getJenkinsServer()).thenReturn(server);
         when(jenkins.getJenkinsServer(project.getKey())).thenReturn(null);
         buildHook.validate(settings, validationErrors, repository);

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHookTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHookTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ExecutorService;
 public class PullRequestHookTest {
 	private final String COMMIT = "commithash";
 	private final String PR_URI = "http://pruri";
-	private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false);
+	private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false, false);
 	private SettingsService settingsService;
 	private Jenkins jenkins;
 	private ApplicationPropertiesService propertiesService;

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServletTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServletTest.java
@@ -74,7 +74,7 @@ public class CIServletTest {
 	@Test
 	public void testDoGetGlobalServer() throws ServletException, IOException, SoyException {
 		when(req.getPathInfo()).thenReturn(GLOBAL_PATH);
-		Server server = new Server("baseurl", null, null, false);
+		Server server = new Server("baseurl", null, null, false, false);
 		when(jenkins.getJenkinsServer()).thenReturn(server);
 		servlet.doGet(req, resp);
 
@@ -118,7 +118,7 @@ public class CIServletTest {
 	@Test
 	public void testDoGetProjectServer() throws ServletException, IOException, SoyException {
 		when(req.getPathInfo()).thenReturn(PROJECT_PATH + PROJECT_KEY);
-		Server server = new Server("baseurl", null, null, false);
+		Server server = new Server("baseurl", null, null, false, false);
 		when(jenkins.getJenkinsServer(PROJECT_KEY)).thenReturn(server);
 		servlet.doGet(req, resp);
 
@@ -175,12 +175,14 @@ public class CIServletTest {
 		String[] defaultUser = {"defaultuser"};
 		String[] defaultToken = {"defaulttoken"};
 		String[] altUrl = {"on"};
+		String[] csrfEnabled = {"on"};
 		String saveButton = "'Save Connection";
 		Map<String, String[]> params = ImmutableMap.<String, String[]>builder()
 				.put("jenkinsUrl", baseUrl)
 				.put("jenkinsUser", defaultUser)
 				.put("jenkinsToken",  defaultToken)
 				.put("jenkinsAltUrl", altUrl)
+				.put("jenkinsCSRF", csrfEnabled)
 				.build();
 
 		when(req.getParameterMap()).thenReturn(params);
@@ -199,12 +201,14 @@ public class CIServletTest {
 		String[] defaultUser = {"defaultuser"};
 		String[] defaultToken = {"defaulttoken"};
 		String[] altUrl = {"on"};
+		String[] csrfEnabled = {"on"};
 		String saveButton = "'Save Connection";
 		Map<String, String[]> params = ImmutableMap.<String, String[]>builder()
 				.put("jenkinsUrl", baseUrl)
 				.put("jenkinsUser", defaultUser)
 				.put("jenkinsToken",  defaultToken)
 				.put("jenkinsAltUrl", altUrl)
+				.put("jenkinsCSRF", csrfEnabled)
 				.build();
 
 		when(req.getParameterMap()).thenReturn(params);
@@ -226,9 +230,10 @@ public class CIServletTest {
 		when(req.getParameter("jenkinsUser")).thenReturn(defaultUser);
 		when(req.getParameter("jenkinsToken")).thenReturn(defaultToken);
 		when(req.getParameter("jenkinsAltUrl")).thenReturn(null);
+		when(req.getParameter("jenkinsCSRF")).thenReturn(null);
 		servlet.doPost(req, resp);
 
-		Server expected = new Server(baseUrl, defaultUser, defaultToken, false);
+		Server expected = new Server(baseUrl, defaultUser, defaultToken, false, false);
 		verify(jenkins, times(1)).saveJenkinsServer(expected);
 	}
 
@@ -240,12 +245,14 @@ public class CIServletTest {
 		String[] defaultUser = {"defaultuser"};
 		String[] defaultToken = {"defaulttoken"};
 		String[] altUrl = {""};
+		String[] csrfEnabled = {"on"};
 		String saveButton = "'Save Connection";
 		Map<String, String[]> params = ImmutableMap.<String, String[]>builder()
 				.put("jenkinsUrl", baseUrl)
 				.put("jenkinsUser", defaultUser)
 				.put("jenkinsToken",  defaultToken)
 				.put("jenkinsAltUrl", altUrl)
+				.put("jenkinsCSRF", csrfEnabled)
 				.build();
 
 		when(req.getParameterMap()).thenReturn(params);
@@ -253,7 +260,7 @@ public class CIServletTest {
 		when(req.getParameter("submit")).thenReturn(saveButton);
 		servlet.doPost(req, resp);
 
-		Server expected = new Server(baseUrl[0], defaultUser[0], defaultToken[0], false);
+		Server expected = new Server(baseUrl[0], defaultUser[0], defaultToken[0], false, false);
 		verify(jenkins, times(1)).saveJenkinsServer(expected);
 	}
 
@@ -264,6 +271,7 @@ public class CIServletTest {
 		String[] defaultUser = {"defaultuser"};
 		String[] defaultToken = {"defaulttoken"};
 		String[] altUrl = {"on"};
+		String[] csrfEnabled = {"on"};
 		String clear = "on";
 		String saveButton = "'Save Connection";
 		Map<String, String[]> params = ImmutableMap.<String, String[]>builder()
@@ -271,6 +279,7 @@ public class CIServletTest {
 				.put("jenkinsUser", defaultUser)
 				.put("jenkinsToken",  defaultToken)
 				.put("jenkinsAltUrl", altUrl)
+				.put("jenkinsCSRF", csrfEnabled)
 				.build();
 
 		when(req.getParameterMap()).thenReturn(params);
@@ -289,6 +298,7 @@ public class CIServletTest {
 		String[] defaultUser = {"defaultuser"};
 		String[] defaultToken = {"defaulttoken"};
 		String[] altUrl = {"on"};
+		String[] csrfEnabled = {"on"};
 		String clear = "";
 		String saveButton = "'Save Connection";
 		Map<String, String[]> params = ImmutableMap.<String, String[]>builder()
@@ -296,6 +306,7 @@ public class CIServletTest {
 				.put("jenkinsUser", defaultUser)
 				.put("jenkinsToken",  defaultToken)
 				.put("jenkinsAltUrl", altUrl)
+				.put("jenkinsCSRF", csrfEnabled)
 				.build();
 
 		when(req.getParameterMap()).thenReturn(params);
@@ -314,12 +325,14 @@ public class CIServletTest {
 		String[] defaultUser = {"defaultuser"};
 		String[] defaultToken = {"defaulttoken"};
 		String[] altUrl = {"on"};
+		String[] csrfEnabled = {"on"};
 		String saveButton = "'Save Connection";
 		Map<String, String[]> params = ImmutableMap.<String, String[]>builder()
 				.put("jenkinsUrl", baseUrl)
 				.put("jenkinsUser", defaultUser)
 				.put("jenkinsToken",  defaultToken)
 				.put("jenkinsAltUrl", altUrl)
+				.put("jenkinsCSRF", csrfEnabled)
 				.build();
 
 		when(req.getParameterMap()).thenReturn(params);
@@ -337,12 +350,14 @@ public class CIServletTest {
 		String[] defaultUser = {"defaultuser"};
 		String[] defaultToken = {"defaulttoken"};
 		String[] altUrl = {"on"};
+		String[] csrfEnabled = {"on"};
 		String saveButton = "'Save Connection";
 		Map<String, String[]> params = ImmutableMap.<String, String[]>builder()
 				.put("jenkinsUrl", baseUrl)
 				.put("jenkinsUser", defaultUser)
 				.put("jenkinsToken",  defaultToken)
 				.put("jenkinsAltUrl", altUrl)
+				.put("jenkinsCSRF", csrfEnabled)
 				.build();
 
 		when(req.getParameterMap()).thenReturn(params);
@@ -362,12 +377,14 @@ public class CIServletTest {
 		String[] defaultUser = {"defaultuser"};
 		String[] defaultToken = {"defaulttoken"};
 		String[] altUrl = {"on"};
+		String[] csrfEnabled = {"on"};
 		String saveButton = "'Save Connection";
 		Map<String, String[]> params = ImmutableMap.<String, String[]>builder()
 				.put("jenkinsUrl", baseUrl)
 				.put("jenkinsUser", defaultUser)
 				.put("jenkinsToken",  defaultToken)
 				.put("jenkinsAltUrl", altUrl)
+				.put("jenkinsCSRF", csrfEnabled)
 				.build();
 
 		when(req.getParameterMap()).thenReturn(params);
@@ -386,6 +403,7 @@ public class CIServletTest {
 		String[] defaultUser = {"defaultuser"};
 		String[] defaultToken = {"defaulttoken"};
 		String[] altUrl = {"on"};
+		String[] csrfEnabled = {"on"};
 		String clear = "on";
 		String saveButton = "'Save Connection";
 		Map<String, String[]> params = ImmutableMap.<String, String[]>builder()
@@ -393,6 +411,7 @@ public class CIServletTest {
 				.put("jenkinsUser", defaultUser)
 				.put("jenkinsToken",  defaultToken)
 				.put("jenkinsAltUrl", altUrl)
+				.put("jenkinsCSRF", csrfEnabled)
 				.build();
 
 		when(req.getParameterMap()).thenReturn(params);
@@ -412,6 +431,7 @@ public class CIServletTest {
 		String[] defaultUser = {"defaultuser"};
 		String[] defaultToken = {"defaulttoken"};
 		String[] altUrl = {"on"};
+		String[] csrfEnabled = {"on"};
 		String clear = "";
 		String saveButton = "'Save Connection";
 		Map<String, String[]> params = ImmutableMap.<String, String[]>builder()
@@ -419,6 +439,7 @@ public class CIServletTest {
 				.put("jenkinsUser", defaultUser)
 				.put("jenkinsToken",  defaultToken)
 				.put("jenkinsAltUrl", altUrl)
+				.put("jenkinsCSRF", csrfEnabled)
 				.build();
 
 		when(req.getParameterMap()).thenReturn(params);

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRAutoMergedHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRAutoMergedHandlerTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.*;
 public class PRAutoMergedHandlerTest {
 
     private final String PR_URL = "http://pruri";
-    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false);
+    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false, false);
     private SettingsService settingsService;
     private Jenkins jenkins;
     private Repository repository;

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRDeclinedHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRDeclinedHandlerTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.*;
 public class PRDeclinedHandlerTest {
 
     private final String PR_URI = "http://pruri";
-    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false);
+    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false, false);
     private SettingsService settingsService;
     private Jenkins jenkins;
     private Repository repository;

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRDeletedHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRDeletedHandlerTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.*;
 public class PRDeletedHandlerTest {
 
     private final String PR_URL = "http://pruri";
-    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false);
+    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false, false);
     private SettingsService settingsService;
     private Jenkins jenkins;
     private Repository repository;

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRHandlerTest.java
@@ -30,7 +30,7 @@ public class PRHandlerTest {
     private final String PROJECT_KEY = "projectkey";
     private final String PROJECT_NAME = "projectname";
     private final String PR_URL = "http://pruri";
-    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false);
+    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false, false);
     private SettingsService settingsService;
     private Jenkins jenkins;
     private Repository repository;

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRMergedHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRMergedHandlerTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 public class PRMergedHandlerTest{
 
     private final String PR_URL = "http://pruri";
-    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false);
+    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false, false);
     private SettingsService settingsService;
     private Jenkins jenkins;
     private Repository repository;

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PROpenedHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PROpenedHandlerTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 public class PROpenedHandlerTest {
 
     private final String PR_URL = "http://pruri";
-    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false);
+    private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false, false);
     private SettingsService settingsService;
     private Jenkins jenkins;
     private Repository repository;

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PushHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PushHandlerTest.java
@@ -29,7 +29,7 @@ public class PushHandlerTest {
     private final String COMMIT = "commithash";
     private final String url = "http://url";
     private final Server projectServer = new Server("projecturl", "projectuser", "projecttoken",
-            false);
+            false, false);
     private Settings settings;
     private RefChange refChange;
     private MinimalRef minimalRef;

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/RefCreatedHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/RefCreatedHandlerTest.java
@@ -29,7 +29,7 @@ public class RefCreatedHandlerTest {
     private final String COMMIT = "commithash";
     private final String url = "http://url";
     private final Server projectServer = new Server("projecturl", "projectuser", "projecttoken",
-            false);
+            false, false);
     private Settings settings;
     private RefChange refChange;
     private MinimalRef minimalRef;

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/RefDeletedHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/RefDeletedHandlerTest.java
@@ -29,7 +29,7 @@ public class RefDeletedHandlerTest {
     private final String COMMIT = "commithash";
     private final String url = "http://url";
     private final Server projectServer = new Server("projecturl", "projectuser", "projecttoken",
-            false);
+            false, false);
     private Settings settings;
     private RefChange refChange;
     private MinimalRef minimalRef;

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/JobTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/JobTest.java
@@ -157,7 +157,7 @@ public class JobTest {
 	@Test
 	public void testBuildUrlNoUserTokenAndUseAltUrl() {
 		String jobName = "jobname";
-		Server server = new Server("http://baseurl", "", "", true);
+		Server server = new Server("http://baseurl", "", "", true, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").build();
 		String actual = job.buildUrl(server, bitbucketVariables, false);
 
@@ -167,7 +167,7 @@ public class JobTest {
 	@Test
 	public void testBuildUrlUserTokenAndUseAltUrl() {
 		String jobName = "jobname";
-		Server server = new Server("http://baseurl", "", "", true);
+		Server server = new Server("http://baseurl", "", "", true, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").build();
 		String actual = job.buildUrl(server, bitbucketVariables, true);
 
@@ -177,7 +177,7 @@ public class JobTest {
 	@Test
 	public void testBuildUrlNoUserTokenAndNoUseAltUrl() {
 		String jobName = "jobname";
-		Server server = new Server("http://baseurl", "", "", false);
+		Server server = new Server("http://baseurl", "", "", false, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").build();
 		String actual = job.buildUrl(server, bitbucketVariables, false);
 
@@ -188,7 +188,7 @@ public class JobTest {
 	public void testBuildUrlNoUserTokenAndLegacyToken() {
 		String jobName = "jobname";
 		String token = "token";
-		Server server = new Server("http://baseurl", "", "", false);
+		Server server = new Server("http://baseurl", "", "", false, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").token(token).build();
 		String actual = job.buildUrl(server, bitbucketVariables, false);
 
@@ -199,7 +199,7 @@ public class JobTest {
 	public void testBuildUrlUserTokenAndLegacyToken() {
 		String jobName = "jobname";
 		String token = "token";
-		Server server = new Server("http://baseurl", "", "", false);
+		Server server = new Server("http://baseurl", "", "", false, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").token(token).build();
 		String actual = job.buildUrl(server, bitbucketVariables, true);
 
@@ -209,7 +209,7 @@ public class JobTest {
 	@Test
 	public void testBuildUrlNoUserTokenAndLegacyTokenEmpty() {
 		String jobName = "jobname";
-		Server server = new Server("http://baseurl", "", "", false);
+		Server server = new Server("http://baseurl", "", "", false, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").token("").build();
 		String actual = job.buildUrl(server, bitbucketVariables, false);
 
@@ -219,7 +219,7 @@ public class JobTest {
 	@Test
 	public void testBuildUrlNotParameterized() {
 		String jobName = "jobname";
-		Server server = new Server("http://baseurl", "", "", false);
+		Server server = new Server("http://baseurl", "", "", false, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").build();
 		String actual = job.buildUrl(server, bitbucketVariables, false);
 
@@ -229,7 +229,7 @@ public class JobTest {
 	@Test
 	public void testBuildPipelineNotParameterizedAndBuild() {
 		String jobName = "jobname";
-		Server server = new Server("http://baseurl", "", "", false);
+		Server server = new Server("http://baseurl", "", "", false, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").isPipeline(true).build();
 		String branch = "test_branch";
 
@@ -245,7 +245,7 @@ public class JobTest {
 	@Test
 	public void testBuildPipelineNotParameterizedAndScan() {
 		String jobName = "jobname";
-		Server server = new Server("http://baseurl", "", "", false);
+		Server server = new Server("http://baseurl", "", "", false, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").isPipeline(true).build();
 		String branch = "test_branch";
 
@@ -258,7 +258,7 @@ public class JobTest {
 	public void testBuildUrlParameterized() {
 		String jobName = "jobname";
 		String params = "param1=value1";
-		Server server = new Server("http://baseurl", "", "", false);
+		Server server = new Server("http://baseurl", "", "", false, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters(params).build();
 		String actual = job.buildUrl(server, bitbucketVariables, false);
 
@@ -270,7 +270,7 @@ public class JobTest {
 	public void testBuildUrlParameterizedButScan() {
 		String jobName = "jobname";
 		String params = "param1=value1";
-		Server server = new Server("http://baseurl", "", "", false);
+		Server server = new Server("http://baseurl", "", "", false, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters(params).isPipeline(true).build();
 		String actual = job.buildUrl(server, bitbucketVariables, false);
 
@@ -281,7 +281,7 @@ public class JobTest {
 	public void testBuildPipelineParameterizedAndBuild() {
 		String jobName = "jobname";
 		String params = "param1=value1";
-		Server server = new Server("http://baseurl", "", "", false);
+		Server server = new Server("http://baseurl", "", "", false, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters(params).isPipeline(true).build();
 		String branch = "test_branch";
 
@@ -299,7 +299,7 @@ public class JobTest {
 	public void testBuildUrlChoiceParameters() {
 		String jobName = "jobname";
 		String params = "param1=1;2;3";
-		Server server = new Server("http://baseurl", "", "", false);
+		Server server = new Server("http://baseurl", "", "", false, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters(params).build();
 		String actual = job.buildUrl(server, bitbucketVariables, false);
 
@@ -314,7 +314,7 @@ public class JobTest {
 		String branch = "branchname";
 		BitbucketVariables vars = new BitbucketVariables.Builder().add("$BRANCH", () -> branch)
 				.add("$TRIGGER", Trigger.ADD::toString).build();
-		Server server = new Server("http://baseurl", "", "", false);
+		Server server = new Server("http://baseurl", "", "", false, false);
 		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters(params).build();
 		String actual = job.buildUrl(server, vars, false);
 

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/ServerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/ServerTest.java
@@ -14,19 +14,21 @@ public class ServerTest {
 		String user = "user";
 		String token = "token";
 		boolean altUrl = false;
-		Server actual = new Server(baseUrl, user, token, altUrl);
+		boolean csrfEnabled = false;
+		Server actual = new Server(baseUrl, user, token, altUrl, csrfEnabled);
 
 		assertEquals(baseUrl, actual.getBaseUrl());
 		assertEquals(user, actual.getUser());
 		assertEquals(token, actual.getToken());
 		assertEquals(altUrl, actual.getAltUrl());
+		assertEquals(csrfEnabled, actual.getCsrfEnabled());
 		assertEquals(user + ":" + token, actual.getJoinedToken());
 	}
 
 	@Test
 	public void testCreateNewServerWithSlash() {
 		String baseUrl = "url";
-		Server actual = new Server(baseUrl + "/", "", "", false);
+		Server actual = new Server(baseUrl + "/", "", "", false, false);
 
 		assertEquals(baseUrl, actual.getBaseUrl());
 	}
@@ -38,6 +40,7 @@ public class ServerTest {
 		expected.put("user", "user");
 		expected.put("token", "token");
 		expected.put("altUrl", false);
+		expected.put("csrfEnabled", false);
 		Map<String, Object> actual = new Server(expected).asMap();
 
 		assertEquals(expected, actual);

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResourceTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResourceTest.java
@@ -57,7 +57,7 @@ public class BuildResourceTest {
 	private ApplicationUser user;
 	private List<Job> jobs;
 	private RepositoryHook hook;
-	private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false);
+	private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false, false);
 
 	@Before
 	public void setup() throws Exception {


### PR DESCRIPTION
We have jenkins listening on a sub-context, not on root path.
However the context was removed from the url when trying to fetch a csrf token.

logic has been separated and added to a jenkins server configuration
the CSRF is now configured by a checkbox per jenkins server

test have been updated accordingly