### PR TITLE
Trigger PR events on target repo rather than source repo

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRHandler.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRHandler.java
@@ -30,7 +30,7 @@ public class PRHandler extends BaseHandler{
         this.pullRequestService = pullRequestService;
         this.pullRequest = event.getPullRequest();
         this.user = pullRequest.getAuthor().getUser();
-        this.repository = pullRequest.getFromRef().getRepository();
+        this.repository = pullRequest.getToRef().getRepository();
         this.projectKey = repository.getProject().getKey();
         this.url = url;
         this.trigger = trigger;

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/TestEventFactory.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/TestEventFactory.java
@@ -62,6 +62,7 @@ public class TestEventFactory {
         when(prFromRef.getDisplayId()).thenReturn(SOURCE_BRANCH);
         when(prFromRef.getLatestCommit()).thenReturn(COMMIT);
         when(prToRef.getDisplayId()).thenReturn(DEST_BRANCH);
+        when(prToRef.getRepository()).thenReturn(repository);
         when(mergeCommit.getId()).thenReturn(newCommit);
     }
 


### PR DESCRIPTION
As issue #119 brought up, we don't trigger PR events when a forked repo created a PR. This is because we set the repo to be the source repo and not the target repo. Therefore, builds still trigger on the forked repo when the forked repo creates a PR but not the original. This doesn't seem to make a whole lot of sense since the target repo is the one that will be impacted by the PR, not the source. 

This change swaps which repo gets the trigger. I plan on adding a possible regression warning to this release if we decide to go this way.