### PR TITLE
Fix multibranch pr triggering

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
@@ -253,7 +253,14 @@ public class Job {
 	private UriBuilder setUrlPath(Server jenkinsServer, boolean useUserToken,
 			boolean hasParameters, Trigger trigger) {
 		UriBuilder builder = UriBuilder.fromUri(jenkinsServer.getBaseUrl());
-		String jobBase = !isPipeline || trigger.isRefChange() ? "%s": "%s%s%s";
+		String jobBase;
+		if ((isPipeline && trigger == Trigger.PULLREQUEST) ||
+			  !isPipeline ||
+			  trigger.isRefChange()) {
+			jobBase = "%s";
+		} else {
+			jobBase = "%s%s%s";
+		}
 		hasParameters = !isPipeline || !trigger.isRefChange() ? hasParameters : false;
 
 		if (useUserToken || !jenkinsServer.getAltUrl()) {

--- a/src/main/resources/scripts/jenkins/pb-pr-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-pr-trigger.js
@@ -15,6 +15,7 @@ define('jenkins/parameterized-build-pullrequest', [
 
     $(".parameterized-build-pullrequest").click(function() {
         var prJSON = require('bitbucket/internal/model/page-state').getPullRequest().toJSON();
+        var prId = prJSON.id;
         var branch = prJSON.fromRef.id;
         var commit = prJSON.fromRef.latestCommit;
         var prDest = prJSON.toRef.displayId;
@@ -27,7 +28,7 @@ define('jenkins/parameterized-build-pullrequest', [
                 var splitBranch = branch.split("/")
                 splitBranch.splice(0, 2) //remove ref/heads or ref/tags
                 var branchName = splitBranch.join("%2F")
-                var buildUrl = getResourceUrl("triggerBuild/0/" + encodeURIComponent(branchName));
+                var buildUrl = getResourceUrl("triggerBuild/0/" + encodeURIComponent(branchName) + "/pr/" + encodeURIComponent(prId));
                 triggerBuild(buildUrl);
                 return false;
             }

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/JobTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/JobTest.java
@@ -249,10 +249,44 @@ public class JobTest {
 		BitbucketVariables vars = new BitbucketVariables.Builder()
 				.add("$TRIGGER", () -> Trigger.PULLREQUEST.toString())
 				.add("$BRANCH", () -> "test_branch")
+				.add("$PRID", () -> "test_pr_id")
 				.build();
 		String actual = job.buildUrl(server, vars, false);
 
 		assertEquals(server.getBaseUrl() + "/job/" + jobName + "/build", actual);
+	}
+
+	@Test
+	public void testBuildUrlMultibranchPullRequestDeleted() {
+		String jobName = "jobname";
+		Server server = new Server("http://baseurl", "", "", false, false);
+		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").isPipeline(true).build();
+
+		BitbucketVariables vars = new BitbucketVariables.Builder()
+				.add("$TRIGGER", () -> Trigger.PRDELETED.toString())
+				.add("$BRANCH", () -> "test_branch")
+				.add("$PRID", () -> "test_pr_id")
+				.build();
+		String actual = job.buildUrl(server, vars, false);
+
+		assertEquals(server.getBaseUrl() + "/job/" + jobName + "/build", actual);
+	}
+
+	@Test
+	public void testBuildUrlMultibranchPullRequestManualTrigger() {
+		String jobName = "jobname";
+		Server server = new Server("http://baseurl", "", "", false, false);
+		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").isPipeline(true).build();
+		String pullRequestId = "test_id";
+
+		BitbucketVariables vars = new BitbucketVariables.Builder()
+				.add("$TRIGGER", () -> Trigger.MANUAL.toString())
+				.add("$BRANCH", () -> "test_branch")
+				.add("$PRID", () -> pullRequestId)
+				.build();
+		String actual = job.buildUrl(server, vars, false);
+
+		assertEquals(server.getBaseUrl() + "/job/" + jobName + "/job/" + "PR-" + pullRequestId + "/build", actual);
 	}
 
 	@Test

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/JobTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/JobTest.java
@@ -241,6 +241,21 @@ public class JobTest {
 	}
 
 	@Test
+	public void testBuildUrlMultibranchPullRequestOpened() {
+		String jobName = "jobname";
+		Server server = new Server("http://baseurl", "", "", false, false);
+		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").isPipeline(true).build();
+
+		BitbucketVariables vars = new BitbucketVariables.Builder()
+				.add("$TRIGGER", () -> Trigger.PULLREQUEST.toString())
+				.add("$BRANCH", () -> "test_branch")
+				.build();
+		String actual = job.buildUrl(server, vars, false);
+
+		assertEquals(server.getBaseUrl() + "/job/" + jobName + "/build", actual);
+	}
+
+	@Test
 	public void testBuildPipelineNotParameterizedAndScan() {
 		String jobName = "jobname";
 		Server server = new Server("http://baseurl", "", "", false, false);

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResourceTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResourceTest.java
@@ -94,7 +94,7 @@ public class BuildResourceTest {
 	@Test
 	public void testTriggerBuildNotAuthed() {
 		when(authContext.isAuthenticated()).thenReturn(false);
-		Response actual = rest.triggerBuild(repository, null, null, null);
+		Response actual = rest.triggerBuild(repository, null, null, null, null);
 
 		assertEquals(Response.Status.FORBIDDEN.getStatusCode(), actual.getStatus());
 	}
@@ -102,7 +102,7 @@ public class BuildResourceTest {
 	@Test
 	public void testTriggerBuildNoRepoSettings() {
 		when(settingsService.getSettings(repository)).thenReturn(null);
-		Response actual = rest.triggerBuild(repository, null, null,null);
+		Response actual = rest.triggerBuild(repository, null, null,null, null);
 
 		assertEquals(Response.Status.NOT_FOUND.getStatusCode(), actual.getStatus());
 	}
@@ -111,7 +111,7 @@ public class BuildResourceTest {
 	public void testTriggerBuildNoMatchingJob() {
 		Job job = new Job.JobBuilder(1).triggers(new String[] { "add" }).build();
 		jobs.add(job);
-		Response actual = rest.triggerBuild(repository, "0", "test",null);
+		Response actual = rest.triggerBuild(repository, "0", "test",null, null);
 
 		Map<String, Object> expected = new LinkedHashMap<>();
 		expected.put("message", "No settings found for this job");
@@ -129,7 +129,7 @@ public class BuildResourceTest {
 		query.add("param2", "value2");
 		when(uriInfo.getQueryParameters()).thenReturn(query);
 		when(jenkins.triggerJob(any(), any(), any(), any())).thenReturn(message);
-		Response results = rest.triggerBuild(repository, "0", "test", uriInfo);
+		Response results = rest.triggerBuild(repository, "0", "test", uriInfo, null);
 
 		assertEquals(Response.Status.OK.getStatusCode(), results.getStatus());
 		assertEquals(message.getMessage(), results.getEntity());


### PR DESCRIPTION
Marking as Work In Progress since unit tests are passing, but I am new to Atlassian plugins I have yet to configure my local Bitbucket Server to test it out. If any anyone can do it too, I would be grateful.

It should solve problems with jobs for PRs not being triggered correctly for multibranch pipelines.
As stated in #109 , the plugin should scan the reposistory for any PR related trigger, and trigger PR jobs directly only from a manual trigger (though in another PR it is possible it will be needed to trigger scan if somehow the job doesn't exist yet)