### PR TITLE
Add name attribute to user jenkins settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>3.2.4</version>
+	<version>3.2.5</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>

--- a/src/main/resources/templates/jenkins-user-settings.soy
+++ b/src/main/resources/templates/jenkins-user-settings.soy
@@ -28,7 +28,8 @@
 				<div>No Jenkins servers were found. Contact your Bitbucket Server administrator to add a Jenkins server.</div>
 			{else}
 			    {call aui.form.submit}
-					{param id: 'submit' /}
+					{param id: 'saveButton' /}
+					{param name: 'submit' /}
 					{param text: 'Save' /}
 					{param type: 'submit' /}
 					{param extraClasses: 'aui-button-primary' /}


### PR DESCRIPTION
With the latest version adding a "Test Jenkins" button on the global and project level settings, a name attribute is required on the form submission buttons to determine what action to take (test or save). These names were added to the project and global jenkins settings soy templates but not the user-level jenkins settings. This is causing a loss of functionality for a significant number of users (see Issue #130). 

This PR adds the missing name attribute, thus fixing the issue. Considering the scope of this bug, I plan to release the new version once this PR is merged.