### PR TITLE
Clean up js dependencies

### DIFF
--- a/src/main/resources/scripts/jenkins/feature/build-dialog.js
+++ b/src/main/resources/scripts/jenkins/feature/build-dialog.js
@@ -4,13 +4,15 @@ define('trigger/build-dialog', [
     'exports',
     'bitbucket/util/state',
     'bitbucket/util/server',
+    'lodash',
     'aui/flag'
 ], function(
-    _aui,
+    AJS,
     $,
     exports,
     pageState,
     server_utils,
+    _,
     flag
 ) {
     var allJobs;
@@ -53,7 +55,7 @@ define('trigger/build-dialog', [
     }
     
     function getResourceUrl(resourceType){
-        return _aui.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().key + '/repos/'
+        return AJS.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().key + '/repos/'
         + pageState.getRepository().slug + '/' + resourceType;
     }
     
@@ -66,7 +68,7 @@ define('trigger/build-dialog', [
     }
 
     function showManualBuildDialog(buildUrl, branch, jobs) {
-        var dialog = _aui.dialog2(com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.fullDialog({
+        var dialog = AJS.dialog2(com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.fullDialog({
                 jobs: jobs,
                 title: AJS.I18n.getText('Build with Parameters')
         })).show();
@@ -171,7 +173,7 @@ define('trigger/build-dialog', [
                 });
             } else if (data.prompt) {
                 var promptCookie = getCookie("jenkinsPrompt");
-                var settingsPath = _aui.contextPath() + "/plugins/servlet/account/jenkins";
+                var settingsPath = AJS.contextPath() + "/plugins/servlet/account/jenkins";
                 if (promptCookie !== "ignore") {
                     flag({
                         type: 'info',

--- a/src/main/resources/scripts/jenkins/feature/build-dialog.js
+++ b/src/main/resources/scripts/jenkins/feature/build-dialog.js
@@ -2,15 +2,15 @@ define('trigger/build-dialog', [
     'aui',
     'jquery',
     'exports',
-    'bitbucket/internal/model/page-state',
-    'bitbucket/internal/util/ajax',
+    'bitbucket/util/state',
+    'bitbucket/util/server',
     'aui/flag'
 ], function(
     _aui,
     $,
     exports,
     pageState,
-    ajax,
+    server_utils,
     flag
 ) {
     var allJobs;
@@ -53,12 +53,12 @@ define('trigger/build-dialog', [
     }
     
     function getResourceUrl(resourceType){
-        return _aui.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().getKey() + '/repos/'
-        + pageState.getRepository().getSlug() + '/' + resourceType;
+        return _aui.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().key + '/repos/'
+        + pageState.getRepository().slug + '/' + resourceType;
     }
     
     function getJobs(resourceUrl){
-        return $.ajax({
+        return server_utils.ajax({
           type: "GET",
           url: resourceUrl,
           dataType: 'json',
@@ -161,7 +161,7 @@ define('trigger/build-dialog', [
             body: 'Build started',
             close: 'auto'
         });
-        ajax.rest({
+        server_utils.rest({
           type: "POST",
           url: buildUrl,
           dataType: 'json',

--- a/src/main/resources/scripts/jenkins/feature/build-dialog.js
+++ b/src/main/resources/scripts/jenkins/feature/build-dialog.js
@@ -66,13 +66,9 @@ define('trigger/build-dialog', [
     }
 
     function showManualBuildDialog(buildUrl, branch, jobs) {
-        var dialog = _aui.dialog2(aui.dialog.dialog2({
-            titleText: AJS.I18n.getText('Build with Parameters'),
-            content: com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.buildDialog({
-                jobs: jobs
-            }),
-            footerActionContent: com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.buildButton(),
-            removeOnHide: true
+        var dialog = _aui.dialog2(com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.fullDialog({
+                jobs: jobs,
+                title: AJS.I18n.getText('Build with Parameters')
         })).show();
         
         var jobSelector = document.getElementById("job");

--- a/src/main/resources/scripts/jenkins/feature/build-dialog.soy
+++ b/src/main/resources/scripts/jenkins/feature/build-dialog.soy
@@ -2,6 +2,25 @@
 
 /**
  * @param jobs
+ * @param title
+ */
+{template .fullDialog}
+    {call aui.dialog.dialog2}
+        {param content}
+            {call .buildDialog}
+                {param jobs : $jobs/}
+            {/call}
+        {/param}
+        {param titleText: $title /}
+        {param removeOnHide: true /}
+        {param footerActionContent}
+            {call .buildButton /}
+        {/param}
+    {/call}
+{/template}
+
+/**
+ * @param jobs
  */
 {template .buildDialog}
     {call aui.form.form}

--- a/src/main/resources/scripts/jenkins/pb-blayout-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-blayout-trigger.js
@@ -1,5 +1,5 @@
 define('jenkins/parameterized-build-layout', [
-    'bitbucket/internal/model/page-state',
+    'bitbucket/util/state',
     'trigger/build-dialog',
     'exports'
 ], function(
@@ -9,7 +9,7 @@ define('jenkins/parameterized-build-layout', [
 ) {
     exports.onReady = function () {
         branchBuild.bindToDropdownLink('.parameterized-build-layout', '#branch-actions-menu', function () {
-            return [pageState.getRevisionRef().getId(), pageState.getRevisionRef().getLatestCommit()];
+            return [pageState.getRef().id, pageState.getRef().latestCommit];
         });
     };
 });

--- a/src/main/resources/scripts/jenkins/pb-pr-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-pr-trigger.js
@@ -1,14 +1,14 @@
 define('jenkins/parameterized-build-pullrequest', [
     'aui',
     'jquery',
-    'bitbucket/internal/model/page-state',
-    'bitbucket/internal/util/ajax',
+    'bitbucket/util/state',
+    'bitbucket/util/server',
     'aui/flag'
 ], function(
     _aui,
     $,
     pageState,
-    ajax,
+    server_util,
     flag
 ) {
     var allJobs;
@@ -40,12 +40,12 @@ define('jenkins/parameterized-build-pullrequest', [
     });
 
     function getResourceUrl(resourceType){
-        return _aui.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().getKey() + '/repos/'
-            + pageState.getRepository().getSlug() + '/' + resourceType;
+        return _aui.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().key + '/repos/'
+            + pageState.getRepository().slug + '/' + resourceType;
     }
 
     function getJobs(resourceUrl){
-        return $.ajax({
+        return server_util.ajax({
             type: "GET",
             url: resourceUrl,
             dataType: 'json',
@@ -148,7 +148,7 @@ define('jenkins/parameterized-build-pullrequest', [
             body: 'Build started',
             close: 'auto'
         });
-        ajax.rest({
+        server_util.rest({
             type: "POST",
             url: buildUrl,
             dataType: 'json',

--- a/src/main/resources/scripts/jenkins/pb-pr-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-pr-trigger.js
@@ -53,13 +53,9 @@ define('jenkins/parameterized-build-pullrequest', [
     }
 
     function showManualBuildDialog(buildUrl, branch, jobs) {
-        var dialog = _aui.dialog2(aui.dialog.dialog2({
-            titleText: AJS.I18n.getText('Build with Parameters'),
-            content: com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.buildDialog({
-                jobs: jobs
-            }),
-            footerActionContent: com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.buildButton(),
-            removeOnHide: true
+        var dialog = _aui.dialog2(com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.fullDialog({
+            jobs: jobs,
+            title: AJS.I18n.getText('Build with Parameters')
         })).show();
 
         var jobSelector = document.getElementById("job");

--- a/src/main/resources/scripts/jenkins/pb-pr-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-pr-trigger.js
@@ -3,12 +3,14 @@ define('jenkins/parameterized-build-pullrequest', [
     'jquery',
     'bitbucket/util/state',
     'bitbucket/util/server',
+    'lodash',
     'aui/flag'
 ], function(
-    _aui,
+    AJS,
     $,
     pageState,
     server_util,
+    _,
     flag
 ) {
     var allJobs;
@@ -40,7 +42,7 @@ define('jenkins/parameterized-build-pullrequest', [
     });
 
     function getResourceUrl(resourceType){
-        return _aui.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().key + '/repos/'
+        return AJS.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().key + '/repos/'
             + pageState.getRepository().slug + '/' + resourceType;
     }
 
@@ -53,7 +55,7 @@ define('jenkins/parameterized-build-pullrequest', [
     }
 
     function showManualBuildDialog(buildUrl, branch, jobs) {
-        var dialog = _aui.dialog2(com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.fullDialog({
+        var dialog = AJS.dialog2(com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.fullDialog({
             jobs: jobs,
             title: AJS.I18n.getText('Build with Parameters')
         })).show();
@@ -158,7 +160,7 @@ define('jenkins/parameterized-build-pullrequest', [
                 });
             } else if (data.prompt) {
                 var promptCookie = getCookie("jenkinsPrompt");
-                var settingsPath = _aui.contextPath() + "/plugins/servlet/account/jenkins";
+                var settingsPath = AJS.contextPath() + "/plugins/servlet/account/jenkins";
                 if (promptCookie !== "ignore") {
                     flag({
                         type: 'info',


### PR DESCRIPTION
Bitbucket strongly recommends not touching internal libraries. Instead we should use the util libraries. We also had a few dependencies that weren't in the define definition (AJS and lodash). I cleaned those up as well.

These changes should not affect functionality in any way. I've tested locally and everything seemed to work as expected.