### PR TITLE
Make sure the merge commit is not null

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRMergedHandler.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRMergedHandler.java
@@ -1,11 +1,14 @@
 package com.kylenicholls.stash.parameterizedbuilds.eventHandlers;
 
+import com.atlassian.bitbucket.commit.MinimalCommit;
 import com.atlassian.bitbucket.event.pull.PullRequestMergedEvent;
 import com.atlassian.bitbucket.pull.PullRequestService;
 import com.kylenicholls.stash.parameterizedbuilds.ciserver.Jenkins;
 import com.kylenicholls.stash.parameterizedbuilds.helper.SettingsService;
 import com.kylenicholls.stash.parameterizedbuilds.item.BitbucketVariables;
 import com.kylenicholls.stash.parameterizedbuilds.item.Job;
+
+import java.util.Optional;
 
 public class PRMergedHandler extends PRHandler{
 
@@ -14,7 +17,9 @@ public class PRMergedHandler extends PRHandler{
     public PRMergedHandler(SettingsService settingsService, PullRequestService pullRequestService, Jenkins jenkins,
                            PullRequestMergedEvent event, String url){
         super(settingsService, pullRequestService, jenkins, event, url, Job.Trigger.PRMERGED);
-        this.mergeCommit = event.getCommit().getId();
+        this.mergeCommit = Optional.ofNullable(event.getCommit())
+                .map(MinimalCommit::getId)
+                .orElse("");
     }
 
     @Override


### PR DESCRIPTION
In the PRMergedHandler we are attempting to get the new commit created by the merge for a bitbucket variable. However on remote merges bitbucket does not populate this value. This was causing a NullPointerException that could be seen in the logs. This PR adds null checking to the mergeCommit.

This should solve issue #166.