### PR TITLE
Add new data center compatibility param

### DIFF
--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -8,6 +8,7 @@
     <param name="plugin-icon">images/icon.png</param>
     <param name="plugin-logo">images/icon.png</param>
     <param name="atlassian-data-center-compatible">true</param>
+    <param name="atlassian-data-center-status">compatible</param>
   </plugin-info>
   
   <!-- add our i18n resource -->


### PR DESCRIPTION
Apparently the Atlassian Marketplace changed the parameter for data center compatibility and so the plugin is no longer showing as data center compatible. This change should fix that.