### PR TITLE
Remove data center compatibility

### DIFF
--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -7,8 +7,6 @@
     <vendor name="${project.organization.name}" url="${project.organization.url}"/>
     <param name="plugin-icon">images/icon.png</param>
     <param name="plugin-logo">images/icon.png</param>
-    <param name="atlassian-data-center-compatible">true</param>
-    <param name="atlassian-data-center-status">compatible</param>
   </plugin-info>
   
   <!-- add our i18n resource -->


### PR DESCRIPTION
Due to new data center plugin requirements, I don't plan on supporting bitbucket data center anymore. The requirements can be found [here](https://developer.atlassian.com/platform/marketplace/dc-apps-submitting-your-app/).

I'm sad to see that we will no longer maintain data center compatibility but I feel I don't have the resources to do all the testing that is required.