### PR TITLE
Allow Jenkins Selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.idea
 *.pack.js
 parameterized-client/node_modules
+.vscode

--- a/parameterized-client/package.json
+++ b/parameterized-client/package.json
@@ -20,6 +20,7 @@
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {
+    "axios": "^0.18.0",
     "react": "^16.5.2",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0"

--- a/parameterized-client/src/hook/job.js
+++ b/parameterized-client/src/hook/job.js
@@ -72,12 +72,25 @@ const JobContainer = ({
     jobInfo,
     errors,
     id,
+    jenkinsServers,
     children,
     toggleJob,
     deleteJob,
     updateText,
     updateTrigger
 }) => {
+    let serverOptions;
+    if (jenkinsServers == null){
+        serverOptions = [
+            <option value={"project"}>project</option>, 
+            <option value={"global"}>global</option>
+        ]
+    } else {
+        serverOptions = [
+            <option value={jenkinsServers["project"]}>{"Project (" + jenkinsServers["project"] + ")"}</option>,
+            <option value={jenkinsServers["global"]}>{"Global (" + jenkinsServers["global"] + ")"}</option>
+        ]
+    }
     return (
         <div id={"job-" + id}>
             <div className={"delete-job inline-button"}>
@@ -92,6 +105,13 @@ const JobContainer = ({
                 </a>
             </div>
             <GenericField jobInfo={jobInfo}  id={id} errors={errors} updateText={updateText} fieldName={"jobName"} fieldLabel={"Job Name"} required={true}/>
+            <div className={"field-group" + (jobInfo.active ? "" : " hidden") }>
+                            <label htmlFor={"jenkinsServer-" + id}>Jenkins Server</label>
+                            <select id={"jenkinsServer-" + id} className={"select"} name={"jenkinsServer-" + id} value={jobInfo.jenkinsServer}
+                                    onChange={e => {updateText(id, 'jenkinsServer', e.target.value)}}>
+                                {serverOptions}
+                            </select>
+                        </div>
             <div className={"field-group" + (jobInfo.active ? "" : " hidden") }>
                 <label htmlFor={"isTag-" + id}>Ref Type</label>
                 <select id={"isTag-" + id} className={"select"} name={"isTag-" + id} value={jobInfo.isTag}
@@ -194,9 +214,10 @@ const JobContainer = ({
 
 const mapStateToJobContainerProps = (state, ownProps) => {
     return {
-        jobInfo: state[ownProps.id],
+        jobInfo: state.jobs[ownProps.id],
         errors: ownProps.errors,
-        id: ownProps.id
+        id: ownProps.id,
+        jenkinsServers: state.jenkinsServers,
     }
 };
 

--- a/parameterized-client/src/hook/job.js
+++ b/parameterized-client/src/hook/job.js
@@ -85,8 +85,12 @@ const JobContainer = ({
         let serverText = server["url"] + " (" + server["scope"] + ")"
         serverOptions.push(<option value={server["project"]}>{serverText}</option>)
     });
-    if (!serverValues.map(server => server["project"]).includes(jobInfo.jenkinsServer) && jobInfo.jenkinsServer){
-        serverOptions.push(<option value={jobInfo.jenkinsServer}>{jobInfo.jenkinsServer}</option>)
+
+    let jenkinsErrors;
+    if (jenkinsServers == null || jenkinsServers.length == 0) {
+        jenkinsErrors = <div className={"error"}>{"No jenkins servers are defined"}</div>
+    } else if (errors["jenkinsServer-" + id] !== 'undefined'){
+        jenkinsErrors = <div className={"error"}>{errors["jenkinsServer-" + id]}</div>
     }
 
     return (
@@ -104,12 +108,14 @@ const JobContainer = ({
             </div>
             <GenericField jobInfo={jobInfo}  id={id} errors={errors} updateText={updateText} fieldName={"jobName"} fieldLabel={"Job Name"} required={true}/>
             <div className={"field-group" + (jobInfo.active ? "" : " hidden") }>
-                            <label htmlFor={"jenkinsServer-" + id}>Jenkins Server</label>
-                            <select id={"jenkinsServer-" + id} className={"select"} name={"jenkinsServer-" + id} value={jobInfo.jenkinsServer}
-                                    onChange={e => {updateText(id, 'jenkinsServer', e.target.value)}}>
-                                {serverOptions}
-                            </select>
-                        </div>
+                <label htmlFor={"jenkinsServer-" + id}>Jenkins Server <span className={"aui-icon icon-required"}/></label>
+                <select id={"jenkinsServer-" + id} className={"select"} name={"jenkinsServer-" + id} value={jobInfo.jenkinsServer}
+                        onChange={e => {updateText(id, 'jenkinsServer', e.target.value)}}
+                        disabled={jenkinsServers == null || jenkinsServers.length == 0}>
+                    {serverOptions}
+                </select>
+                {jenkinsErrors}
+            </div>
             <div className={"field-group" + (jobInfo.active ? "" : " hidden") }>
                 <label htmlFor={"isTag-" + id}>Ref Type</label>
                 <select id={"isTag-" + id} className={"select"} name={"isTag-" + id} value={jobInfo.isTag}

--- a/parameterized-client/src/hook/job.js
+++ b/parameterized-client/src/hook/job.js
@@ -82,8 +82,9 @@ const JobContainer = ({
     let serverValues = jenkinsServers == null ? []: jenkinsServers;
     let serverOptions = [<option value={""}>Choose an option</option>];
     serverValues.forEach(server => {
-        let serverText = server["url"] + " (" + server["scope"] + ")"
-        serverOptions.push(<option value={server["project"]}>{serverText}</option>)
+        let serverText = server["url"] + " (" + server["scope"] + ")";
+        let serverValue = server["scope"] == "project" ? server["project"] : "global-settings" ;
+        serverOptions.push(<option value={serverValue}>{serverText}</option>)
     });
 
     let jenkinsErrors;

--- a/parameterized-client/src/hook/job.js
+++ b/parameterized-client/src/hook/job.js
@@ -79,18 +79,16 @@ const JobContainer = ({
     updateText,
     updateTrigger
 }) => {
-    let serverOptions;
-    if (jenkinsServers == null){
-        serverOptions = [
-            <option value={"project"}>project</option>, 
-            <option value={"global"}>global</option>
-        ]
-    } else {
-        serverOptions = [
-            <option value={jenkinsServers["project"]}>{"Project (" + jenkinsServers["project"] + ")"}</option>,
-            <option value={jenkinsServers["global"]}>{"Global (" + jenkinsServers["global"] + ")"}</option>
-        ]
+    let serverValues = jenkinsServers == null ? []: jenkinsServers;
+    let serverOptions = [<option value={""}>Choose an option</option>];
+    serverValues.forEach(server => {
+        let serverText = server["url"] + " (" + server["scope"] + ")"
+        serverOptions.push(<option value={server["project"]}>{serverText}</option>)
+    });
+    if (!serverValues.map(server => server["project"]).includes(jobInfo.jenkinsServer) && jobInfo.jenkinsServer){
+        serverOptions.push(<option value={jobInfo.jenkinsServer}>{jobInfo.jenkinsServer}</option>)
     }
+
     return (
         <div id={"job-" + id}>
             <div className={"delete-job inline-button"}>

--- a/parameterized-client/src/hook/state-reducers.js
+++ b/parameterized-client/src/hook/state-reducers.js
@@ -3,6 +3,7 @@ const getInitialState = () => {
         id: null,
         active: true,
         jobName: "",
+        jenkinsServers: null,
         isTag: false,
         isPipeline: false,
         triggers: "",
@@ -56,6 +57,11 @@ const jobState = (state=getInitialState(), action) => {
                     triggers: state.triggers + action.value
                 }
             }
+        case 'UPDATE_JENKINS_SERVERS':
+            return {
+                ...state,
+                jenkinsServers: action.servers
+            }
         default:
             return state
     }
@@ -69,6 +75,7 @@ const createInitialState = (config) => {
             id: i,
             active: false,
             jobName: config["jobName-" + i],
+            jenkinsServers: config["jenkinsServer-" + i],
             isTag: config["isTag-" + i] == 'true',
             isPipeline: config["isPipeline-" + i],
             triggers: config["triggers-" + i],
@@ -88,7 +95,7 @@ const createInitialState = (config) => {
     return initialState;
 };
 
-export const jobs = (state = [], action) => {
+const jobs = (state = [], action) => {
     switch (action.type) {
         case 'INITIALIZE':
             return createInitialState(action.baseConfig);
@@ -112,8 +119,25 @@ export const jobs = (state = [], action) => {
             return state.map(t => jobState(t, action));
         case 'UPDATE_TRIGGER_FIELD':
             return state.map(t => jobState(t, action));
+        case 'UPDATE_JENKINS_SERVERS':
+            return state.map(t => jobState(t, action));
         default:
             return state
+    }
+};
+
+export const jobDefinitions = (state = {jobs: [], jenkinsServers: {}}, action) => {
+    switch (action.type){
+        case 'UPDATE_JENKINS_SERVERS':
+            return {
+                ...state,
+                jenkinsServers: action.servers
+            }
+        default:
+            return {
+                ...state,
+                jobs: jobs(state.jobs, action)
+            }
     }
 };
 

--- a/parameterized-client/src/hook/state-reducers.js
+++ b/parameterized-client/src/hook/state-reducers.js
@@ -3,7 +3,7 @@ const getInitialState = () => {
         id: null,
         active: true,
         jobName: "",
-        jenkinsServers: null,
+        jenkinsServer: null,
         isTag: false,
         isPipeline: false,
         triggers: "",
@@ -57,11 +57,6 @@ const jobState = (state=getInitialState(), action) => {
                     triggers: state.triggers + action.value
                 }
             }
-        case 'UPDATE_JENKINS_SERVERS':
-            return {
-                ...state,
-                jenkinsServers: action.servers
-            }
         default:
             return state
     }
@@ -75,7 +70,7 @@ const createInitialState = (config) => {
             id: i,
             active: false,
             jobName: config["jobName-" + i],
-            jenkinsServers: config["jenkinsServer-" + i],
+            jenkinsServer: config["jenkinsServer-" + i],
             isTag: config["isTag-" + i] == 'true',
             isPipeline: config["isPipeline-" + i],
             triggers: config["triggers-" + i],
@@ -119,14 +114,12 @@ const jobs = (state = [], action) => {
             return state.map(t => jobState(t, action));
         case 'UPDATE_TRIGGER_FIELD':
             return state.map(t => jobState(t, action));
-        case 'UPDATE_JENKINS_SERVERS':
-            return state.map(t => jobState(t, action));
         default:
             return state
     }
 };
 
-export const jobDefinitions = (state = {jobs: [], jenkinsServers: {}}, action) => {
+export const jobDefinitions = (state = {jobs: [], jenkinsServers: []}, action) => {
     switch (action.type){
         case 'UPDATE_JENKINS_SERVERS':
             return {

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
@@ -101,6 +101,10 @@ public class ParameterizedBuildHook
 				errors.addFieldError(SettingsService.JOB_PREFIX + i, "Field is required");
 			}
 
+			if (job.getJenkinsServer().isEmpty()) {
+				errors.addFieldError(SettingsService.SERVER_PREFIX + i, "You must choose a jenkins server");
+			}
+
 			if (job.getTriggers().contains(Trigger.NULL)) {
 				errors.addFieldError(SettingsService.TRIGGER_PREFIX
 						+ i, "You must choose at least one trigger");

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHook.java
@@ -87,7 +87,7 @@ public class ParameterizedBuildHook
 	public void validate(Settings settings, SettingsValidationErrors errors, Scope scope) {
 		String projectKey = scope.accept(new ScopeProjectVisitor()).getKey();
 		Server projectServer = jenkins.getJenkinsServer(projectKey);
-		Server server = jenkins.getJenkinsServer();
+		Server server = jenkins.getJenkinsServer(null);
 
 		if ((server == null || server.getBaseUrl().isEmpty())
 				&& (projectServer == null || projectServer.getBaseUrl().isEmpty())) {

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServerFactory.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServerFactory.java
@@ -33,7 +33,7 @@ public class CIServerFactory {
             Server server = jenkins.getJenkinsServer(projectKey);
             return new ProjectServer(jenkins, server, projectKey);
         } else {
-            Server server =jenkins.getJenkinsServer();
+            Server server =jenkins.getJenkinsServer(null);
             return new GlobalServer(jenkins, server);
         }
     }

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/helper/SettingsService.java
@@ -22,6 +22,7 @@ public class SettingsService {
 	private static final Logger logger = LoggerFactory.getLogger(SettingsService.class);
 	private static final String KEY = "com.kylenicholls.stash.parameterized-builds:parameterized-build-hook";
 	public static final String JOB_PREFIX = "jobName-";
+	public static final String SERVER_PREFIX = "jenkinsServer-";
 	public static final String ISTAG_PREFIX = "isTag-";
 	public static final String TRIGGER_PREFIX = "triggers-";
 	public static final String TOKEN_PREFIX = "token-";
@@ -88,6 +89,8 @@ public class SettingsService {
 		for (Map.Entry<String, Object> entry : parameterMap.entrySet()) {
 			if (entry.getKey().startsWith(JOB_PREFIX)) {
 				Job job = new Job.JobBuilder(jobsList.size()).jobName(entry.getValue().toString())
+						.jenkinsServer(fetchValue(entry.getKey().replace(JOB_PREFIX, SERVER_PREFIX),
+								parameterMap, ""))
 						.isTag(fetchValue(entry.getKey().replace(JOB_PREFIX, ISTAG_PREFIX),
 								parameterMap, false))
 						.triggers(parameterMap

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
@@ -17,6 +17,7 @@ public class Job {
 	private static final Logger logger = LoggerFactory.getLogger(Job.class);
 	private final int jobId;
 	private final String jobName;
+	private final String jenkinsServer;
 	private final boolean isTag;
 	private final List<Trigger> triggers;
 	private final String token;
@@ -30,6 +31,7 @@ public class Job {
 	private Job(JobBuilder builder) {
 		this.jobId = builder.jobId;
 		this.jobName = builder.jobName;
+		this.jenkinsServer = builder.jenkinsServer;
 		this.isTag = builder.isTag;
 		this.triggers = builder.triggers;
 		this.token = builder.token;
@@ -107,6 +109,7 @@ public class Job {
 	public static class JobBuilder {
 		private final int jobId;
 		private String jobName;
+		private String jenkinsServer;
 		private boolean isTag;
 		private List<Trigger> triggers;
 		private String token;
@@ -123,6 +126,11 @@ public class Job {
 
 		public JobBuilder jobName(String jobName) {
 			this.jobName = jobName;
+			return this;
+		}
+
+		public JobBuilder jenkinsServer(String jenkinsServer){
+			this.jenkinsServer = jenkinsServer;
 			return this;
 		}
 
@@ -221,9 +229,9 @@ public class Job {
 	}
 
 	public JobBuilder copy(){
-		return new JobBuilder(jobId).jobName(jobName).isTag(isTag).triggers(triggers).token(token)
-				.buildParameters(buildParameters).branchRegex(branchRegex).pathRegex(pathRegex).permissions(permissions)
-				.prDestRegex(prDestRegex).isPipeline(isPipeline);
+		return new JobBuilder(jobId).jobName(jobName).jenkinsServer(jenkinsServer).isTag(isTag).triggers(triggers)
+				.token(token).buildParameters(buildParameters).branchRegex(branchRegex).pathRegex(pathRegex)
+				.permissions(permissions).prDestRegex(prDestRegex).isPipeline(isPipeline);
 	}
 
 	public String buildUrl(Server jenkinsServer, BitbucketVariables bitbucketVariables,

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
@@ -51,6 +51,10 @@ public class Job {
 		return jobName;
 	}
 
+	public String getJenkinsServer() {
+		return jenkinsServer;
+	}
+
 	public boolean getIsTag() {
 		return isTag;
 	}

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
@@ -114,7 +114,7 @@ public class BuildResource extends RestResource {
 		if (authContext.isAuthenticated()) {
 			String projectKey = repository.getProject().getKey();
 			List<Map<String, String>> servers = new ArrayList<>();
-			
+
 			Optional.ofNullable(jenkins.getJenkinsServer(projectKey))
 					.map(x -> createServerMap(x, projectKey)).ifPresent(servers::add);
 			Optional.ofNullable(jenkins.getJenkinsServer())

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
@@ -117,7 +117,7 @@ public class BuildResource extends RestResource {
 
 			Optional.ofNullable(jenkins.getJenkinsServer(projectKey))
 					.map(x -> createServerMap(x, projectKey)).ifPresent(servers::add);
-			Optional.ofNullable(jenkins.getJenkinsServer())
+			Optional.ofNullable(jenkins.getJenkinsServer(null))
 					.map(x -> createServerMap(x, null)).ifPresent(servers::add);
 
 			return Response.ok(servers).build();

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResource.java
@@ -30,6 +30,7 @@ import com.atlassian.bitbucket.server.ApplicationPropertiesService;
 import com.atlassian.bitbucket.setting.Settings;
 import com.atlassian.bitbucket.user.ApplicationUser;
 import com.atlassian.plugins.rest.common.security.AnonymousAllowed;
+import com.google.common.collect.Lists;
 import com.kylenicholls.stash.parameterizedbuilds.ciserver.Jenkins;
 import com.kylenicholls.stash.parameterizedbuilds.conditions.BuildPermissionsCondition;
 import com.kylenicholls.stash.parameterizedbuilds.helper.SettingsService;
@@ -37,6 +38,7 @@ import com.kylenicholls.stash.parameterizedbuilds.item.BitbucketVariables;
 import com.kylenicholls.stash.parameterizedbuilds.item.BitbucketVariables.Builder;
 import com.kylenicholls.stash.parameterizedbuilds.item.Job;
 import com.kylenicholls.stash.parameterizedbuilds.item.Job.Trigger;
+import com.kylenicholls.stash.parameterizedbuilds.item.Server;
 import com.sun.jersey.spi.resource.Singleton;
 
 @Path(ResourcePatterns.REPOSITORY_URI)
@@ -104,6 +106,24 @@ public class BuildResource extends RestResource {
 			}
 		}
 		return Response.status(Response.Status.FORBIDDEN).build();
+	}
+
+	@GET
+	@Path(value = "getJenkinsServers")
+	public Response getJenkinsServers(@Context final Repository repository){
+		if (authContext.isAuthenticated()) {
+			String projectKey = repository.getProject().getKey();
+			String projectServer = Optional.ofNullable(jenkins.getJenkinsServer(projectKey))
+					.map(Server::getBaseUrl).orElse("");
+			String globalServer = Optional.ofNullable(jenkins.getJenkinsServer())
+					.map(Server::getBaseUrl).orElse("");
+			Map<String, String> data = new HashMap<>();
+			data.put("global", globalServer);
+			data.put("project", projectServer);
+			return Response.ok(data).build();
+		} else {
+			return Response.status(Response.Status.FORBIDDEN).build();
+		}
 	}
 
 	@GET

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHookTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHookTest.java
@@ -198,8 +198,8 @@ public class ParameterizedBuildHookTest {
 
     @Test
     public void testShowErrorIfJobNameEmpty() {
-        Job job = new Job.JobBuilder(1).jobName("").triggers("add".split(";")).buildParameters("")
-                .branchRegex("").pathRegex("").build();
+        Job job = new Job.JobBuilder(1).jobName("").jenkinsServer("test").triggers("add".split(";"))
+                .buildParameters("").branchRegex("").pathRegex("").build();
         jobs.add(job);
         buildHook.validate(settings, validationErrors, repositoryScope);
 
@@ -208,9 +208,20 @@ public class ParameterizedBuildHookTest {
     }
 
     @Test
+    public void testShowErrorIfJenkinsServerEmpty() {
+        Job job = new Job.JobBuilder(1).jobName("name").jenkinsServer("").triggers("add".split(";"))
+                .buildParameters("").branchRegex("").pathRegex("").build();
+        jobs.add(job);
+        buildHook.validate(settings, validationErrors, repositoryScope);
+
+        verify(validationErrors, times(1))
+                .addFieldError(SettingsService.SERVER_PREFIX + "0", "You must choose a jenkins server");
+    }
+
+    @Test
     public void testShowErrorIfTriggersEmpty() {
-        Job job = new Job.JobBuilder(1).jobName("name").triggers("".split(";")).buildParameters("")
-                .branchRegex("").pathRegex("").build();
+        Job job = new Job.JobBuilder(1).jobName("name").jenkinsServer("test").triggers("".split(";"))
+                .buildParameters("").branchRegex("").pathRegex("").build();
         jobs.add(job);
         buildHook.validate(settings, validationErrors, repositoryScope);
 
@@ -220,8 +231,8 @@ public class ParameterizedBuildHookTest {
 
     @Test
     public void testShowErrorIfBranchRegexInvalid() {
-        Job job = new Job.JobBuilder(1).jobName("name").triggers("add".split(";"))
-                .buildParameters("").branchRegex("(").pathRegex("").build();
+        Job job = new Job.JobBuilder(1).jobName("name").jenkinsServer("test")
+                .triggers("add".split(";")).buildParameters("").branchRegex("(").pathRegex("").build();
         jobs.add(job);
         buildHook.validate(settings, validationErrors, repositoryScope);
 
@@ -231,7 +242,7 @@ public class ParameterizedBuildHookTest {
 
     @Test
     public void testShowErrorIfPathRegexInvalid() {
-        Job job = new Job.JobBuilder(1).jobName("name").triggers("add".split(";"))
+        Job job = new Job.JobBuilder(1).jobName("name").jenkinsServer("test").triggers("add".split(";"))
                 .buildParameters("").branchRegex("").pathRegex("(").build();
         jobs.add(job);
         buildHook.validate(settings, validationErrors, repositoryScope);

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHookTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ParameterizedBuildHookTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.when;
 public class ParameterizedBuildHookTest {
     private final String BRANCH_REF = "refs/heads/branch";
     private final String COMMIT = "commithash";
+    private final String PROJECT_KEY = "projectkey";
     private final String REPO_SLUG = "reposlug";
     private final String URI = "http://uri";
     private final Server globalServer = new Server("globalurl", "globaluser", "globaltoken", false, false);
@@ -98,9 +99,10 @@ public class ParameterizedBuildHookTest {
         when(repository.getSlug()).thenReturn(REPO_SLUG);
         when(repository.getProject()).thenReturn(project);
         when(repositoryScope.accept(any())).thenReturn(project);
-        when(jenkins.getJenkinsServer()).thenReturn(globalServer);
+        when(jenkins.getJenkinsServer(null)).thenReturn(globalServer);
         when(jenkins.getJenkinsServer(project.getKey())).thenReturn(projectServer);
         when(propertiesService.getBaseUrl()).thenReturn(new URI(URI));
+        when(project.getKey()).thenReturn(PROJECT_KEY);
 
         when(minimalRef.getId()).thenReturn(BRANCH_REF);
         jobBuilder = new Job.JobBuilder(1).jobName("").buildParameters("").branchRegex("")
@@ -135,7 +137,7 @@ public class ParameterizedBuildHookTest {
 
     @Test
     public void testShowErrorIfJenkinsSettingsNull() {
-        when(jenkins.getJenkinsServer()).thenReturn(null);
+        when(jenkins.getJenkinsServer(null)).thenReturn(null);
         when(jenkins.getJenkinsServer(project.getKey())).thenReturn(null);
         buildHook.validate(settings, validationErrors, repositoryScope);
 
@@ -146,7 +148,7 @@ public class ParameterizedBuildHookTest {
     @Test
     public void testShowErrorIfBaseUrlEmpty() {
         Server server = new Server("", null, null, false, false);
-        when(jenkins.getJenkinsServer()).thenReturn(server);
+        when(jenkins.getJenkinsServer(null)).thenReturn(server);
         when(jenkins.getJenkinsServer(project.getKey())).thenReturn(server);
         buildHook.validate(settings, validationErrors, repositoryScope);
 
@@ -157,7 +159,7 @@ public class ParameterizedBuildHookTest {
     @Test
     public void testShowErrorIfJenkinsSettingsUrlEmpty() {
         Server server = new Server("", null, null, false, false);
-        when(jenkins.getJenkinsServer()).thenReturn(server);
+        when(jenkins.getJenkinsServer(null)).thenReturn(server);
         when(jenkins.getJenkinsServer(project.getKey())).thenReturn(null);
         buildHook.validate(settings, validationErrors, repositoryScope);
 
@@ -167,7 +169,7 @@ public class ParameterizedBuildHookTest {
 
     @Test
     public void testShowErrorIfProjectSettingsUrlEmpty() {
-        when(jenkins.getJenkinsServer()).thenReturn(null);
+        when(jenkins.getJenkinsServer(null)).thenReturn(null);
         Server server = new Server("", null, null, false, false);
         when(jenkins.getJenkinsServer(project.getKey())).thenReturn(server);
         buildHook.validate(settings, validationErrors, repositoryScope);
@@ -178,7 +180,7 @@ public class ParameterizedBuildHookTest {
 
     @Test
     public void testNoErrorIfOnlyJenkinsSettingsNull() {
-        when(jenkins.getJenkinsServer()).thenReturn(null);
+        when(jenkins.getJenkinsServer(null)).thenReturn(null);
         Server server = new Server("baseurl", null, null, false, false);
         when(jenkins.getJenkinsServer(project.getKey())).thenReturn(server);
         buildHook.validate(settings, validationErrors, repositoryScope);
@@ -189,7 +191,7 @@ public class ParameterizedBuildHookTest {
     @Test
     public void testNoErrorIfOnlyProjectSettingsNull() {
         Server server = new Server("baseurl", null, null, false, false);
-        when(jenkins.getJenkinsServer()).thenReturn(server);
+        when(jenkins.getJenkinsServer(null)).thenReturn(server);
         when(jenkins.getJenkinsServer(project.getKey())).thenReturn(null);
         buildHook.validate(settings, validationErrors, repositoryScope);
 

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHookTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/PullRequestHookTest.java
@@ -70,7 +70,7 @@ public class PullRequestHookTest {
 
 		when(repository.getProject()).thenReturn(project);
 		when(settingsService.getSettings(repository)).thenReturn(settings);
-		when(jenkins.getJenkinsServer()).thenReturn(globalServer);
+		when(jenkins.getJenkinsServer(null)).thenReturn(globalServer);
 		when(settingsService.getHook(any())).thenReturn(repoHook);
 		when(repoHook.isEnabled()).thenReturn(true);
 

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServletTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/CIServletTest.java
@@ -75,7 +75,7 @@ public class CIServletTest {
 	public void testDoGetGlobalServer() throws ServletException, IOException, SoyException {
 		when(req.getPathInfo()).thenReturn(GLOBAL_PATH);
 		Server server = new Server("baseurl", null, null, false, false);
-		when(jenkins.getJenkinsServer()).thenReturn(server);
+		when(jenkins.getJenkinsServer(null)).thenReturn(server);
 		servlet.doGet(req, resp);
 
 		Map<String, Object> data = ImmutableMap.of(
@@ -89,7 +89,7 @@ public class CIServletTest {
 	@Test
 	public void testDoGetGlobalServerNull() throws ServletException, IOException, SoyException {
 		when(req.getPathInfo()).thenReturn(GLOBAL_PATH);
-		when(jenkins.getJenkinsServer()).thenReturn(null);
+		when(jenkins.getJenkinsServer(null)).thenReturn(null);
 		servlet.doGet(req, resp);
 
 		Map<String, Object> data = ImmutableMap.of(
@@ -104,7 +104,7 @@ public class CIServletTest {
 	public void testDoGetAccountServerNull() throws ServletException, IOException, SoyException {
 		List<UserToken> projectTokens = new ArrayList<>();
 		when(req.getPathInfo()).thenReturn(ACCOUNT_PATH);
-		when(jenkins.getJenkinsServer()).thenReturn(null);
+		when(jenkins.getJenkinsServer(null)).thenReturn(null);
 		when(jenkins.getAllUserTokens(user, new ArrayList<String>(), projectService))
 				.thenReturn(projectTokens);
 		servlet.doGet(req, resp);

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRHandlerTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRHandlerTest.java
@@ -56,7 +56,7 @@ public class PRHandlerTest {
         when(project.getName()).thenReturn(PROJECT_NAME);
         when(project.getKey()).thenReturn(PROJECT_KEY);
         when(settingsService.getSettings(repository)).thenReturn(settings);
-        when(jenkins.getJenkinsServer()).thenReturn(globalServer);
+        when(jenkins.getJenkinsServer(null)).thenReturn(globalServer);
         when(settingsService.getHook(any())).thenReturn(repoHook);
         when(repoHook.isEnabled()).thenReturn(true);
 

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRTestBase.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/eventHandlers/PRTestBase.java
@@ -45,7 +45,7 @@ public class PRTestBase {
 
         when(repository.getProject()).thenReturn(project);
         when(settingsService.getSettings(repository)).thenReturn(settings);
-        when(jenkins.getJenkinsServer()).thenReturn(globalServer);
+        when(jenkins.getJenkinsServer(null)).thenReturn(globalServer);
         when(settingsService.getHook(any())).thenReturn(repoHook);
         when(repoHook.isEnabled()).thenReturn(true);
 

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResourceTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/BuildResourceTest.java
@@ -78,7 +78,7 @@ public class BuildResourceTest {
 		when(authContext.getCurrentUser()).thenReturn(user);
 		when(settingsService.getSettings(repository)).thenReturn(settings);
 		when(repository.getProject()).thenReturn(project);
-		when(jenkins.getJenkinsServer()).thenReturn(globalServer);
+		when(jenkins.getJenkinsServer(null)).thenReturn(globalServer);
 		when(repository.getSlug()).thenReturn(REPO_SLUG);
 		when(project.getKey()).thenReturn(PROJECT_KEY);
 		when(propertiesService.getBaseUrl()).thenReturn(new URI(URI));


### PR DESCRIPTION
This PR introduces a new option in the job definitions. Users can now choose to use either the global or project jenkins server to run their jobs on. Only servers that are defined will be available to choose from.

I'm not sure how useful this feature will be on it's own but it sets up a lot of the code we need to allow users to specify multiple jenkins servers per project.