### PR TITLE
Bitbucket Server 6.0.0 Compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>3.2.10</version>
+	<version>4.0.0</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>
@@ -307,10 +307,10 @@
 		</plugins>
 	</build>
 	<properties>
-		<bitbucket.server.version>5.4.0</bitbucket.server.version>
-		<bitbucket.data.version>5.4.0</bitbucket.data.version>
+		<bitbucket.server.version>6.0.0</bitbucket.server.version>
+		<bitbucket.data.version>6.0.0</bitbucket.data.version>
 		<atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
-		<amps.version>6.3.4</amps.version>
+		<amps.version>6.3.21</amps.version>
 		<plugin.testrunner.version>1.2.0</plugin.testrunner.version>
 	</properties>
 </project>

--- a/src/main/resources/scripts/jenkins/feature/build-dialog.js
+++ b/src/main/resources/scripts/jenkins/feature/build-dialog.js
@@ -1,5 +1,5 @@
 define('trigger/build-dialog', [
-    'aui',
+    'aui/dialog2',
     'jquery',
     'exports',
     'bitbucket/util/state',
@@ -7,7 +7,7 @@ define('trigger/build-dialog', [
     'lodash',
     'aui/flag'
 ], function(
-    AJS,
+    dialog2,
     $,
     exports,
     pageState,
@@ -16,6 +16,9 @@ define('trigger/build-dialog', [
     flag
 ) {
     var allJobs;
+
+    var urlRegex = /(.+?)\/projects\/\w+?\/repos\/\w+?\/.*/
+    var urlParts = window.location.href.match(urlRegex);
 
     function bindToDropdownLink(linkSelector, dropDownSelector, getBranchNameFunction) {
         $(document).on('aui-dropdown2-show', dropDownSelector, function () {
@@ -55,7 +58,7 @@ define('trigger/build-dialog', [
     }
     
     function getResourceUrl(resourceType){
-        return AJS.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().key + '/repos/'
+        return urlParts[1] + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().key + '/repos/'
         + pageState.getRepository().slug + '/' + resourceType;
     }
     
@@ -68,9 +71,9 @@ define('trigger/build-dialog', [
     }
 
     function showManualBuildDialog(buildUrl, branch, jobs) {
-        var dialog = AJS.dialog2(com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.fullDialog({
+        var dialog = dialog2(com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.fullDialog({
                 jobs: jobs,
-                title: AJS.I18n.getText('Build with Parameters')
+                title: 'Build with Parameters'
         })).show();
         
         var jobSelector = document.getElementById("job");
@@ -173,7 +176,7 @@ define('trigger/build-dialog', [
                 });
             } else if (data.prompt) {
                 var promptCookie = getCookie("jenkinsPrompt");
-                var settingsPath = AJS.contextPath() + "/plugins/servlet/account/jenkins";
+                var settingsPath = urlParts[1] + "/plugins/servlet/account/jenkins";
                 if (promptCookie !== "ignore") {
                     flag({
                         type: 'info',

--- a/src/main/resources/scripts/jenkins/pb-blayout-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-blayout-trigger.js
@@ -14,6 +14,6 @@ define('jenkins/parameterized-build-layout', [
     };
 });
 
-require('aui').$(document).ready(function () {
+$(document).ready(function () {
     require('jenkins/parameterized-build-layout').onReady();
 });

--- a/src/main/resources/scripts/jenkins/pb-blist-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-blist-trigger.js
@@ -14,6 +14,6 @@ define('jenkins/parameterized-build-branchlist', [
     };
 });
 
-require('aui').$(document).ready(function () {
+$(document).ready(function () {
     require('jenkins/parameterized-build-branchlist').onReady();
 });

--- a/src/main/resources/scripts/jenkins/pb-pr-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-pr-trigger.js
@@ -1,12 +1,12 @@
 define('jenkins/parameterized-build-pullrequest', [
-    'aui',
+    'aui/dialog2',
     'jquery',
     'bitbucket/util/state',
     'bitbucket/util/server',
     'lodash',
     'aui/flag'
 ], function(
-    AJS,
+    dialog2,
     $,
     pageState,
     server_util,
@@ -14,6 +14,8 @@ define('jenkins/parameterized-build-pullrequest', [
     flag
 ) {
     var allJobs;
+    var urlRegex = /(.+?)\/projects\/\w+?\/repos\/\w+?\/.*/
+    var urlParts = window.location.href.match(urlRegex);
 
     $(".parameterized-build-pullrequest").click(function() {
         var prJSON = require('bitbucket/internal/model/page-state').getPullRequest().toJSON();
@@ -42,7 +44,7 @@ define('jenkins/parameterized-build-pullrequest', [
     });
 
     function getResourceUrl(resourceType){
-        return AJS.contextPath() + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().key + '/repos/'
+        return urlParts[1] + '/rest/parameterized-builds/latest/projects/' + pageState.getProject().key + '/repos/'
             + pageState.getRepository().slug + '/' + resourceType;
     }
 
@@ -55,9 +57,9 @@ define('jenkins/parameterized-build-pullrequest', [
     }
 
     function showManualBuildDialog(buildUrl, branch, jobs) {
-        var dialog = AJS.dialog2(com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.fullDialog({
+        var dialog = dialog2(com.kylenicholls.stash.parameterizedbuilds.jenkins.branchBuild.fullDialog({
             jobs: jobs,
-            title: AJS.I18n.getText('Build with Parameters')
+            title: 'Build with Parameters'
         })).show();
 
         var jobSelector = document.getElementById("job");
@@ -160,7 +162,7 @@ define('jenkins/parameterized-build-pullrequest', [
                 });
             } else if (data.prompt) {
                 var promptCookie = getCookie("jenkinsPrompt");
-                var settingsPath = AJS.contextPath() + "/plugins/servlet/account/jenkins";
+                var settingsPath = urlParts[1] + "/plugins/servlet/account/jenkins";
                 if (promptCookie !== "ignore") {
                     flag({
                         type: 'info',
@@ -196,6 +198,6 @@ define('jenkins/parameterized-build-pullrequest', [
     }
 });
 
-require('aui').$(document).ready(function() {
+$(document).ready(function() {
     require('jenkins/parameterized-build-pullrequest');
 });


### PR DESCRIPTION
The only deprecated library we are still using is aui. aui has been split up into several different packages. 

The modals we use in manual builds now require aui/dialog instead. I could not find an AMD valid i18n package so I removed it for now. I also could not find where the contextPath helper function moved to. I think atlassian may have removed it entirely so I'm stripping it out of the window.location.href instead.

I've tested that regular automated builds trigger normally, as do manual builds on all pages. However, I think the pop-up for user credentials may be broken. I'll see if I can fix it but I think we can probably leave it broken for now if need be.