### PR TITLE
Update regex to include repo-specific special characters

### DIFF
--- a/parameterized-client/src/hook/view.js
+++ b/parameterized-client/src/hook/view.js
@@ -8,7 +8,7 @@ import axios from 'axios';
 window.parameterizedbuilds = window.parameterizedbuilds || {};
 
 const getJenkinsServers = () => {
-    const urlRegex = /(.+?)(\/projects\/\w+?\/repos\/\w+?\/)settings.*/
+    const urlRegex = /(.+?)(\/projects\/[\w_ -]+?\/repos\/[\w_ -]+?\/)settings.*/
     let urlParts = window.location.href.match(urlRegex);
     let restUrl = urlParts[1] + "/rest/parameterized-builds/latest" + urlParts[2] + "getJenkinsServers";
     return axios.get(restUrl, {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>4.0.0</version>
+	<version>4.0.1</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>

--- a/src/main/resources/scripts/jenkins/feature/build-dialog.js
+++ b/src/main/resources/scripts/jenkins/feature/build-dialog.js
@@ -17,7 +17,7 @@ define('trigger/build-dialog', [
 ) {
     var allJobs;
 
-    var urlRegex = /(.+?)\/projects\/\w+?\/repos\/\w+?\/.*/
+    var urlRegex = /(.+?)\/projects\/[\w_ -]+?\/repos\/[\w_ -]+?\/.*/
     var urlParts = window.location.href.match(urlRegex);
 
     function bindToDropdownLink(linkSelector, dropDownSelector, getBranchNameFunction) {

--- a/src/main/resources/scripts/jenkins/pb-pr-trigger.js
+++ b/src/main/resources/scripts/jenkins/pb-pr-trigger.js
@@ -14,7 +14,7 @@ define('jenkins/parameterized-build-pullrequest', [
     flag
 ) {
     var allJobs;
-    var urlRegex = /(.+?)\/projects\/\w+?\/repos\/\w+?\/.*/
+    var urlRegex = /(.+?)\/projects\/[\w_ -]+?\/repos\/[\w_ -]+?\/.*/
     var urlParts = window.location.href.match(urlRegex);
 
     $(".parameterized-build-pullrequest").click(function() {


### PR DESCRIPTION
The 4.0.0 version introduced javascript code that assumed repo slugs would only contain alphanumeric characters. This is not true for new versions of bitbucket server and caused the repo hook settings to fail to load (see #183).

This PR updates the regular expressions used to parse repository slugs to include all characters allowed in repository names.