### PR TITLE
Expect any character in project and repo names

### DIFF
--- a/parameterized-client/src/hook/view.js
+++ b/parameterized-client/src/hook/view.js
@@ -8,7 +8,7 @@ import axios from 'axios';
 window.parameterizedbuilds = window.parameterizedbuilds || {};
 
 const getJenkinsServers = () => {
-    const urlRegex = /(.+?)(\/projects\/[\w_ -]+?\/repos\/[\w_ -]+?\/)settings.*/
+    const urlRegex = /(.+?)(\/projects\/.+?\/repos\/.+?\/)settings.*/
     let urlParts = window.location.href.match(urlRegex);
     let restUrl = urlParts[1] + "/rest/parameterized-builds/latest" + urlParts[2] + "getJenkinsServers";
     return axios.get(restUrl, {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kylenicholls.stash</groupId>
 	<artifactId>parameterized-builds</artifactId>
-	<version>4.0.1</version>
+	<version>4.0.2</version>
 
 	<organization>
 		<name>Kyle Nicholls</name>

--- a/src/main/resources/scripts/jenkins/feature/build-dialog.js
+++ b/src/main/resources/scripts/jenkins/feature/build-dialog.js
@@ -17,7 +17,7 @@ define('trigger/build-dialog', [
 ) {
     var allJobs;
 
-    var urlRegex = /(.+?)\/projects\/[\w_ -]+?\/repos\/[\w_ -]+?\/.*/
+    var urlRegex = /(.+?)\/projects\/.+?\/repos\/.+?\/.*/
     var urlParts = window.location.href.match(urlRegex);
 
     function bindToDropdownLink(linkSelector, dropDownSelector, getBranchNameFunction) {


### PR DESCRIPTION
Relates to the recent comment in #183. 

According to Bitbucket, "Repository names are limited to 128 characters. They must start with a letter or number and may contain spaces, hyphens, underscores and periods" Therefore, we should only have to add periods to the square brackets. However, it is possible Bitbucket could change this so might as well just allow any characters.

I've only tested that this works with the view.js file but I see no reason it would be problematic in the build-dialog.