### PR TITLE
add proper support for forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Built-in variables:
   * $PRDESCRIPTION: description of the PR (may be empty)
   * $PRAUTHOR: display name of the author of the PR
   * $PRURL: bitbucket URL of the PR
+  * $PRSOURCEPROJECT: the project where the source branch of a PR resides (if not using a fork then this is the same as $PROJECT)
+  * $PRSOURCEREPOSITORY: the repository where the source branch of a PR resides (if not using a fork then this is the same as $REPOSITORY)
   * $MERGECOMMIT: the commit hash of the commit on the destination branch caused by the PR merge. Only available to `PR MERGED` trigger
 
 Parameter Types:

--- a/parameterized-client/src/hook/job.js
+++ b/parameterized-client/src/hook/job.js
@@ -181,7 +181,7 @@ const JobContainer = ({
                 <div className={"description"}>
                     {"Key=Value pairs separated by new line. For choice parameters separate values with a semicolon. " +
                      "Available Bitbucket variables: $BRANCH, $COMMIT, $REPOSITORY, $PROJECT, $TRIGGER (for PR triggers " +
-                     "also $PRID, $PRTITLE, $PRDESTINATION, $PRAUTHOR, $PRDESCRIPTION, $PRURL, and for PR MERGED triggers " +
+                     "also $PRID, $PRTITLE, $PRDESTINATION, $PRAUTHOR, $PRDESCRIPTION, $PRURL, $PRSOURCEPROJECT, $PRSOURCEREPOSITORY, and for PR MERGED triggers " +
                      "$MERGECOMMIT))"}
                 </div>
             </div>

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/BitbucketVariables.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/BitbucketVariables.java
@@ -16,7 +16,7 @@ public class BitbucketVariables {
 	private final String [] SET_VALUES = {
 			"$BRANCH", "$COMMIT", "$URL", "$REPOSITORY", "$PROJECT", "$PRID",
 			"$PRAUTHOR", "$PRTITLE", "$PRDESCRIPTION", "$PRDESTINATION",
-			"$PRURL", "$TRIGGER", "$MERGECOMMIT",};
+			"$PRURL", "$TRIGGER", "$MERGECOMMIT","$PRSOURCEPROJECT", "$PRSOURCEREPOSITORY",};
 	private final Set<String> allowedVariables = new HashSet<>(Arrays.asList(SET_VALUES));
 
 	private BitbucketVariables(Builder builder){
@@ -64,6 +64,8 @@ public class BitbucketVariables {
 					.add("$PRDESTINATION", () ->  pullRequest.getToRef().getDisplayId())
 					.add("$PRURL", () -> url + "/projects/" + projectKey + "/repos/" +
 							repository.getSlug() + "/pull-requests/" + prId)
+					.add("$PRSOURCEPROJECT",  () -> pullRequest.getFromRef().getRepository().getProject().getKey())
+					.add("$PRSOURCEREPOSITORY", () -> pullRequest.getFromRef().getRepository().getSlug())
 					.add("$TRIGGER", trigger::toString);
 		}
 

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/BitbucketVariablesTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/BitbucketVariablesTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.atlassian.bitbucket.project.Project;
 import com.atlassian.bitbucket.pull.PullRequest;
 import com.atlassian.bitbucket.pull.PullRequestParticipant;
 import com.atlassian.bitbucket.pull.PullRequestRef;
@@ -24,10 +25,12 @@ public class BitbucketVariablesTest {
 	private Repository repository;
 
 	private final String projectKey = "projectkey";
+	private final String forkProjectKey = "forkprojectkey";
 	private final Trigger trigger = Trigger.NULL;
 	private final String url = "http://uri";
 	private final String PR_TITLE = "prtitle";
 	private final String REPO_SLUG = "reposlug";
+	private final String FORK_REPO_SLUG = "forkreposlug";
 	private final Long PR_ID = 15L;
 	private final String PR_DESCRIPTION = "Description of this PR";
 	private final String PR_AUTHOR = "this guy";
@@ -40,6 +43,8 @@ public class BitbucketVariablesTest {
 		pullRequest = mock(PullRequest.class);
 		refChange = mock(RefChange.class);
 		repository = mock(Repository.class);
+		Repository forkRepository = mock(Repository.class);
+		Project forkProject = mock(Project.class);
 		branch = mock(Branch.class);
 
 		PullRequestParticipant author = mock(PullRequestParticipant.class);
@@ -59,11 +64,14 @@ public class BitbucketVariablesTest {
 		when(branch.getLatestCommit()).thenReturn(COMMIT);
 		when(author.getUser()).thenReturn(user);
 		when(user.getDisplayName()).thenReturn(PR_AUTHOR);
-		when(prFromRef.getRepository()).thenReturn(repository);
+		when(prFromRef.getRepository()).thenReturn(forkRepository);
 		when(prFromRef.getDisplayId()).thenReturn(SOURCE_BRANCH);
 		when(prFromRef.getLatestCommit()).thenReturn(COMMIT);
 		when(prToRef.getDisplayId()).thenReturn(DEST_BRANCH);
 		when(repository.getSlug()).thenReturn(REPO_SLUG);
+		when(forkRepository.getSlug()).thenReturn(FORK_REPO_SLUG);
+		when(forkRepository.getProject()).thenReturn(forkProject);
+		when(forkProject.getKey()).thenReturn(forkProjectKey);
 	}
 
 	@Test
@@ -170,6 +178,22 @@ public class BitbucketVariablesTest {
 				.populateFromPR(pullRequest, repository, projectKey, trigger, url).build();
 
 		assertEquals(trigger.toString(), actual.fetch("$TRIGGER"));
+	}
+
+	@Test
+	public void testPopulateFromPRSetsSourceProject() {
+		BitbucketVariables actual = new BitbucketVariables.Builder()
+				.populateFromPR(pullRequest, repository, projectKey, trigger, url).build();
+
+		assertEquals(forkProjectKey, actual.fetch("$PRSOURCEPROJECT"));
+	}
+
+	@Test
+	public void testPopulateFromPRSetsSourceRepository() {
+		BitbucketVariables actual = new BitbucketVariables.Builder()
+				.populateFromPR(pullRequest, repository, projectKey, trigger, url).build();
+
+		assertEquals(FORK_REPO_SLUG, actual.fetch("$PRSOURCEREPOSITORY"));
 	}
 
 	@Test


### PR DESCRIPTION
it is now possible to trigger jenkins also on pull requests which were
created from a fork.

two new variables were introduced for this:
$PRSOURCEPROJECT:    the PROJECT where the source repository resides
$PRSOURCEREPOSITORY: the REPOSITORY where the source branch resides

the existing $PROJECT and $REPOSITORY will continue to point to the
destination, even though it might have been more logical to flip the two
(instead introducing $PRTARGET[PROJECT|REPOSITORY]) so that all jobs can
just use $PROJECT and $REPOSITORY and not care whether it is a pull
request or not. however, this would be a breaking change for existing
consumers which use $PROJECT and $REPOSITORY in a fork-setup on pull
requests (though they currently can't actually build the project since
they lack the necessary information).

this closes KyleLNicholls/parameterized-builds#194