### PR TITLE
Rest docs workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,3 @@ jdk:
 cache:
   directories:
   - $HOME/.m2
-script: mvn test -B -Dmaven.javadoc.skip=true

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -96,7 +96,6 @@
       <param-name>extension.filter.excludes</param-name>
       <param-value>.*</param-value>
     </init-param>
-    <package>com.kylenicholls.stash.parameterizedbuilds.rest</package>
   </rest>
   
   <!-- web items -->


### PR DESCRIPTION
A recent AMPS update broke rest doc generation for projects with rest components (see [this atlassian issue](https://community.developer.atlassian.com/t/error-when-trying-to-build-my-jira-projects-failed-to-execute-goal-com-atlassian-maven-plugins8-0-0-generate-rest-docs/27070)). The current workaround is to remove the package attribute of the rest component in the atlassian-plugin.xml file. This PR resolves #201.