### PR TITLE
Fix admin settings

### DIFF
--- a/parameterized-client/src/common/aui.js
+++ b/parameterized-client/src/common/aui.js
@@ -50,10 +50,11 @@ export const Button = ({
     buttonText,
     onClick= () => {},
     type = "submit",
+    disabled = false,
     extraClasses = [],
 }) => (
     <input id={id} className={"aui-button " + extraClasses.join(' ')}
-           name={name} value={buttonText} type={type} onClick={onClick} />
+           name={name} value={buttonText} type={type} onClick={onClick} disabled={disabled} aria-disabled={disabled}/>
 )
 
 export const ButtonGroup = ({ children }) => (

--- a/parameterized-client/src/common/rest.js
+++ b/parameterized-client/src/common/rest.js
@@ -20,7 +20,7 @@ export const getJenkinsServers = (context, projectKey) => {
 
 export const saveJenkinsServer = (context, projectKey, serverData) => {
     const baseUrl = getRestUrl(context);
-    const alias = serverData.old_alias !== undefined ? serverData.old_alias : serverData.alias;
+    const alias = serverData.old_alias !== "" ? serverData.old_alias : serverData.alias;
     let fullUrl = projectKey === "" ?
         `${baseUrl}/global/servers/${alias}` :
         `${baseUrl}/projects/${projectKey}/servers/${alias}`;

--- a/parameterized-client/src/jenkins_settings/server.js
+++ b/parameterized-client/src/jenkins_settings/server.js
@@ -39,11 +39,13 @@ const ServerContainer = ({
 
     const saveServer = e => {
         e.preventDefault();
-        updateServer(serverData.id, "action_message", "Saving settings...")
-        updateServer(serverData.id, "action_state", "LOADING")
+        updateServer(serverData.id, "action_message", "Saving settings...");
+        updateServer(serverData.id, "action_state", "LOADING");
+        const newAlias = serverData.alias;
         saveJenkinsServer(context, project, serverData).then(response => {
             updateServer(serverData.id, "action_message", "Settings saved!")
             updateServer(serverData.id, "action_state", "SUCCESS")
+            updateServer(serverData.id, "old_alias", newAlias)
         }).catch(error => {
             const message = `Failed to save settings:\n${error.response.data.errors.join('\n')}`
             updateServer(serverData.id, "action_message", message)
@@ -53,7 +55,7 @@ const ServerContainer = ({
 
     const deleteServer = e => {
         e.preventDefault();
-        const alias = serverData.old_alias !== undefined ? serverData.old_alias : serverData.alias;
+        const alias = serverData.old_alias !== "" ? serverData.old_alias : serverData.alias;
         updateServer(serverData.id, "show_clear_modal", false)
         updateServer(serverData.id, "action_message", "Removing settings...")
         updateServer(serverData.id, "action_state", "LOADING")
@@ -115,7 +117,7 @@ const ServerContainer = ({
                 <Button id="testButton" name="button" buttonText="Test Jenkins Settings"
                         onClick={testServer}/>
                 <Button id="clearButton" name="button" buttonText="Clear Jenkins Settings"
-                        onClick={(e) => toggleModal(e, true)} />
+                        onClick={(e) => toggleModal(e, true)} disabled={serverData.old_alias === ""} />
             </ButtonGroup>
             {serverData.action_message !== "" && 
                 <ActionDialog message={serverData.action_message} state={serverData.action_state}/>}
@@ -126,7 +128,7 @@ const ServerContainer = ({
                     <Button id="confirmDeleteButton" name="button" buttonText="Clear Settings"
                             onClick={deleteServer} />
                    )]}>
-                <p>Are you sure you want to clear settings for {serverData.alias}?</p>
+                <p>Are you sure you want to clear settings for {serverData.alias}? This action cannot be undone.</p>
             </Modal>
         </div>
     );


### PR DESCRIPTION
This PR fixes a bad null check that prevented jenkins settings from being saved if no settings already existed. It also adds some tweaks to the clear settings button to be more responsive. 