### PR TITLE
Allow special characters in build parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.9</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -178,8 +178,8 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.1.1</version>
-            <scope>test</scope>
+            <version>4.5.9</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kylenicholls.stash</groupId>
     <artifactId>parameterized-builds</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4</version>
 
     <organization>
         <name>Kyle Nicholls</name>

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
@@ -266,6 +266,14 @@ public class Job {
 					buildUrl = buildUrl.replace(encodedVar, bitbucketVariables.fetch(variable));
 				}
 			}
+			// also try to replace unencoded variables just in case
+			if (buildUrl.contains(variable) && bitbucketVariables.fetch(variable) != null) {
+				try {
+					buildUrl = buildUrl.replace(variable, URLEncoder.encode(bitbucketVariables.fetch(variable), "UTF-8"));
+				} catch (UnsupportedEncodingException e) {
+					buildUrl = buildUrl.replace(variable, bitbucketVariables.fetch(variable));
+				}
+			}
 		}
 
 		return buildUrl;

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/ServerService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/ServerService.java
@@ -1,5 +1,6 @@
 package com.kylenicholls.stash.parameterizedbuilds.rest;
 
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -19,6 +20,8 @@ import javax.ws.rs.core.UriInfo;
 
 import com.atlassian.bitbucket.rest.util.RestUtils;
 import com.kylenicholls.stash.parameterizedbuilds.item.Server;
+
+import org.apache.http.client.utils.URIBuilder;
 
 public interface ServerService {
 
@@ -60,7 +63,18 @@ public interface ServerService {
         List<String> errors = new ArrayList<>(2);
         if (server.getBaseUrl() == null || server.getBaseUrl().isEmpty()){
             errors.add("Base Url required.");
+        } else {
+            URIBuilder builder;
+            try {
+                builder = new URIBuilder(server.getBaseUrl());
+                if (builder.getHost() == null){
+                    errors.add("Invalide Base Url.");
+                }
+            } catch (URISyntaxException e) {
+                errors.add("Invalide Base Url.");
+            }
         }
+
         if (server.getAlias() == null || server.getAlias().isEmpty()){
             errors.add("Alias required.");
         }

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/JenkinsTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/JenkinsTest.java
@@ -173,7 +173,7 @@ public class JenkinsTest {
 
 	@Test
 	public void testGetAllUserTokensWithGlobalServer() {
-		Server globalServer = new Server("globalUrl", null, "globaluser", "globaltoken", false, false);
+		Server globalServer = new Server("http://globalUrl", null, "globaluser", "globaltoken", false, false);
 		String token = "token";
 		List<String> projectKeys = new ArrayList<>();
 		when(pluginSettings.get(".jenkinsSettings")).thenReturn(globalServer.asMap());
@@ -199,7 +199,7 @@ public class JenkinsTest {
 
 	@Test
 	public void testGetAllUserTokensProjectServerNull() {
-		Server globalServer = new Server("globalUrl", null, "globaluser", "globaltoken", false, false);
+		Server globalServer = new Server("http://globalUrl", null, "globaluser", "globaltoken", false, false);
 		String newProjectKey = "newkey";
 		List<String> projectKeys = new ArrayList<>();
 		projectKeys.add(newProjectKey);
@@ -212,7 +212,7 @@ public class JenkinsTest {
 
 	@Test
 	public void testGetAllUserTokensProjectServerTokenNull() {
-		Server globalServer = new Server("globalUrl", null, "globaluser", "globaltoken", false, false);
+		Server globalServer = new Server("http://globalUrl", null, "globaluser", "globaltoken", false, false);
 		String newProjectKey = "newkey";
 		String newProjectName = "newName";
 		List<String> projectKeys = new ArrayList<>();
@@ -220,7 +220,7 @@ public class JenkinsTest {
 		when(pluginSettings.get(".jenkinsSettings")).thenReturn(globalServer.asMap());
 		when(projectService.getByKey(newProjectKey)).thenReturn(project);
 		when(project.getName()).thenReturn(newProjectName);
-		Server projectServer = new Server("newbaseurl", null, "newuser", "newtoken", false, false);
+		Server projectServer = new Server("http://newbaseurl", null, "newuser", "newtoken", false, false);
 		when(pluginSettings.get(".jenkinsSettings." + newProjectKey))
 				.thenReturn(projectServer.asMap());
 		List<UserToken> actual = jenkins.getAllUserTokens(user, projectKeys, projectService);
@@ -235,7 +235,7 @@ public class JenkinsTest {
 
 	@Test
 	public void testGetAllUserTokensProjectServer() {
-		Server globalServer = new Server("globalUrl", null, "globaluser", "globaltoken", false, false);
+		Server globalServer = new Server("http://globalUrl", null, "globaluser", "globaltoken", false, false);
 		String newProjectKey = "newkey";
 		String newProjectName = "newName";
 		String token = "token";
@@ -246,7 +246,7 @@ public class JenkinsTest {
 		when(project.getName()).thenReturn(newProjectName);
 		when(pluginSettings.get(".jenkinsUser." + USER_SLUG + "." + newProjectKey))
 				.thenReturn(token);
-		Server projectServer = new Server("newbaseurl", null, "newuser", "newtoken", false, false);
+		Server projectServer = new Server("http://newbaseurl", null, "newuser", "newtoken", false, false);
 		when(pluginSettings.get(".jenkinsSettings." + newProjectKey))
 				.thenReturn(projectServer.asMap());
 		List<UserToken> actual = jenkins.getAllUserTokens(user, projectKeys, projectService);
@@ -259,69 +259,69 @@ public class JenkinsTest {
 	public void testTriggerJobUseJobServer(){
 		String userToken = USER_SLUG + ":token";
 		String userCSRF = null;
-		Server expected = new Server("globalurl", null, user.getDisplayName(), "token", false, false);
+		Server expected = new Server("http://globalurl", null, user.getDisplayName(), "token", false, false);
 		when(pluginSettings.get(".jenkinsSettings." + PROJECT_KEY)).thenReturn(expected.asMap());
 		when(pluginSettings.get(".jenkinsUser." + USER_SLUG + "." + PROJECT_KEY)).thenReturn("token");
 
-		Job job = new Job.JobBuilder(1).jobName("").buildParameters("").branchRegex("").jenkinsServer(PROJECT_KEY)
+		Job job = new Job.JobBuilder(1).jobName("testJob").buildParameters("").branchRegex("").jenkinsServer(PROJECT_KEY)
 				.pathRegex("").prDestRegex("").build();
 		BitbucketVariables bitbucketVariables = new BitbucketVariables.Builder().add("$TRIGGER", () -> Job.Trigger.ADD.toString()).build();
 		Jenkins jenkinsSpy = spy(jenkins);
 		jenkinsSpy.triggerJob(PROJECT_KEY, user, job, bitbucketVariables);
 
-		verify(jenkinsSpy, times(1)).sanitizeTrigger("globalurl/job/build", userToken, userCSRF, false);
+		verify(jenkinsSpy, times(1)).sanitizeTrigger("http://globalurl/job/testJob/build", userToken, userCSRF, false);
 	}
 
 	@Test
 	public void testTriggerJobUseJobServerGlobal(){
 		String userToken = USER_SLUG + ":token";
 		String userCSRF = null;
-		Server expected = new Server("globalurl", null, user.getDisplayName(), "token", false, false);
+		Server expected = new Server("http://globalurl", null, user.getDisplayName(), "token", false, false);
 		when(pluginSettings.get(".jenkinsSettings." + PROJECT_KEY)).thenReturn(expected.asMap());
 		when(pluginSettings.get(".jenkinsUser." + USER_SLUG + "." + PROJECT_KEY)).thenReturn("token");
 
-		Job job = new Job.JobBuilder(1).jobName("").buildParameters("").branchRegex("").jenkinsServer(PROJECT_KEY)
+		Job job = new Job.JobBuilder(1).jobName("testJob").buildParameters("").branchRegex("").jenkinsServer(PROJECT_KEY)
 				.pathRegex("").prDestRegex("").build();
 		BitbucketVariables bitbucketVariables = new BitbucketVariables.Builder().add("$TRIGGER", () -> Job.Trigger.ADD.toString()).build();
 		Jenkins jenkinsSpy = spy(jenkins);
 		jenkinsSpy.triggerJob(PROJECT_KEY, user, job, bitbucketVariables);
 
-		verify(jenkinsSpy, times(1)).sanitizeTrigger("globalurl/job/build", userToken, userCSRF, false);
+		verify(jenkinsSpy, times(1)).sanitizeTrigger("http://globalurl/job/testJob/build", userToken, userCSRF, false);
 	}
 
 	@Test
 	public void testTriggerJobUseProjectServerAndUserToken(){
 		String userToken = USER_SLUG + ":token";
 		String userCSRF = null;
-		Server expected = new Server("globalurl", null, user.getDisplayName(), "token", false, false);
+		Server expected = new Server("http://globalurl", null, user.getDisplayName(), "token", false, false);
 		when(pluginSettings.get(".jenkinsSettings." + PROJECT_KEY)).thenReturn(expected.asMap());
 		when(pluginSettings.get(".jenkinsUser." + USER_SLUG + "." + PROJECT_KEY)).thenReturn("token");
 
-		Job job = new Job.JobBuilder(1).jobName("").buildParameters("").branchRegex("")
+		Job job = new Job.JobBuilder(1).jobName("testJob").buildParameters("").branchRegex("")
 				.pathRegex("").prDestRegex("").build();
 		BitbucketVariables bitbucketVariables = new BitbucketVariables.Builder().add("$TRIGGER", () -> Job.Trigger.ADD.toString()).build();
 		Jenkins jenkinsSpy = spy(jenkins);
 		jenkinsSpy.triggerJob(PROJECT_KEY, user, job, bitbucketVariables);
 
-		verify(jenkinsSpy, times(1)).sanitizeTrigger("globalurl/job/build", userToken, userCSRF, false);
+		verify(jenkinsSpy, times(1)).sanitizeTrigger("http://globalurl/job/testJob/build", userToken, userCSRF, false);
 	}
 
 	@Test
 	public void testTriggerJobUseGlobalJenkinsAndUserToken(){
 		String userToken = USER_SLUG + ":token";
 		String userCSRF = null;
-		Server expected = new Server("globalurl", null, user.getDisplayName(), "token", false, false);
+		Server expected = new Server("http://globalurl", null, user.getDisplayName(), "token", false, false);
 		when(pluginSettings.get(".jenkinsSettings." + PROJECT_KEY)).thenReturn(null);
 		when(pluginSettings.get(".jenkinsSettings")).thenReturn(expected.asMap());
 		when(pluginSettings.get(".jenkinsUser." + USER_SLUG)).thenReturn("token");
 
-		Job job = new Job.JobBuilder(1).jobName("").buildParameters("").branchRegex("")
+		Job job = new Job.JobBuilder(1).jobName("testJob").buildParameters("").branchRegex("")
 				.pathRegex("").prDestRegex("").build();
 		BitbucketVariables bitbucketVariables =  new BitbucketVariables.Builder().add("$TRIGGER", () -> Job.Trigger.ADD.toString()).build();;
 		Jenkins jenkinsSpy = spy(jenkins);
 		jenkinsSpy.triggerJob(PROJECT_KEY, user, job, bitbucketVariables);
 
-		verify(jenkinsSpy, times(1)).sanitizeTrigger("globalurl/job/build", userToken, userCSRF, false);
+		verify(jenkinsSpy, times(1)).sanitizeTrigger("http://globalurl/job/testJob/build", userToken, userCSRF, false);
 	}
 
 	@Test
@@ -329,31 +329,31 @@ public class JenkinsTest {
 		String userToken = USER_SLUG + ":token";
 		String userCSRF = null;
 		when(user.getDisplayName()).thenReturn(USER_SLUG);
-		Server expected = new Server("globalurl", null, user.getDisplayName(), "token", false, false);
+		Server expected = new Server("http://globalurl", null, user.getDisplayName(), "token", false, false);
 		when(pluginSettings.get(".jenkinsSettings." + PROJECT_KEY)).thenReturn(expected.asMap());
 
-		Job job = new Job.JobBuilder(1).jobName("").buildParameters("").branchRegex("")
+		Job job = new Job.JobBuilder(1).jobName("testJob").buildParameters("").branchRegex("")
 				.pathRegex("").prDestRegex("").build();
 		BitbucketVariables bitbucketVariables =  new BitbucketVariables.Builder().add("$TRIGGER", () -> Job.Trigger.ADD.toString()).build();;
 		Jenkins jenkinsSpy = spy(jenkins);
 		jenkinsSpy.triggerJob(PROJECT_KEY, user, job, bitbucketVariables);
 
-		verify(jenkinsSpy, times(1)).sanitizeTrigger("globalurl/job/build", userToken, userCSRF, true);
+		verify(jenkinsSpy, times(1)).sanitizeTrigger("http://globalurl/job/testJob/build", userToken, userCSRF, true);
 	}
 
 	@Test
 	public void testTriggerJobNoDefaultUserSet(){
 		when(user.getDisplayName()).thenReturn("user");
-		Server expected = new Server("globalurl", "", "", "", false, false);
+		Server expected = new Server("http://globalurl", "", "", "", false, false);
 		when(pluginSettings.get(".jenkinsSettings." + PROJECT_KEY)).thenReturn(expected.asMap());
 
-		Job job = new Job.JobBuilder(1).jobName("").buildParameters("").branchRegex("")
+		Job job = new Job.JobBuilder(1).jobName("testJob").buildParameters("").branchRegex("")
 				.pathRegex("").prDestRegex("").build();
 		BitbucketVariables bitbucketVariables = new BitbucketVariables.Builder().add("$TRIGGER", () -> Job.Trigger.ADD.toString()).build();
 		Jenkins jenkinsSpy = spy(jenkins);
 		jenkinsSpy.triggerJob(PROJECT_KEY, user, job, bitbucketVariables);
 
-		verify(jenkinsSpy, times(1)).sanitizeTrigger("globalurl/job/build", null, null, true);
+		verify(jenkinsSpy, times(1)).sanitizeTrigger("http://globalurl/job/testJob/build", null, null, true);
 	}
 
 	@Test

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/JobTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/JobTest.java
@@ -22,7 +22,10 @@ public class JobTest {
 
 	@Before
 	public void setup() throws IOException {
-		bitbucketVariables = new BitbucketVariables.Builder().add("$TRIGGER", Job.Trigger.ADD::toString).build();
+		bitbucketVariables = new BitbucketVariables.Builder()
+			.add("$TRIGGER", Job.Trigger.ADD::toString)
+			.add("$BRANCH", () -> "test_branch")
+			.build();
 	}
 	@Test
 	public void testBuildJobId() {
@@ -147,6 +150,16 @@ public class JobTest {
 		String actual = job.buildUrl(null, null, false);
 
 		assertEquals(null, actual);
+	}
+
+	@Test
+	public void testBuildUrlSubsVariablesInJobName() {
+		String jobName = "$BRANCH";
+		Server server = new Server("http://baseurl", null, "", "", false, false);
+		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters("").build();
+		String actual = job.buildUrl(server, bitbucketVariables, false);
+
+		assertEquals(server.getBaseUrl() + "/job/" + bitbucketVariables.fetch(jobName) + "/build", actual);
 	}
 
 	@Test

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/JobTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/item/JobTest.java
@@ -1,6 +1,8 @@
 package com.kylenicholls.stash.parameterizedbuilds.item;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
@@ -312,6 +314,22 @@ public class JobTest {
 
 		assertEquals(server.getBaseUrl() + "/job/" + jobName + "/buildWithParameters?"
 				+ params.replace("$BRANCH", branch), actual);
+	}
+
+	@Test
+	public void testBuildUrlWithSpecialChars() throws UnsupportedEncodingException {
+		String jobName = "jobname";
+		String params = "param1=\"{\"GIT_BRANCH\":\"$BRANCH\"}";
+		String branch = "branchname";
+		BitbucketVariables vars = new BitbucketVariables.Builder().add("$BRANCH", () -> branch)
+				.add("$TRIGGER", Trigger.ADD::toString).build();
+		Server server = new Server("http://baseurl", null, "", "", false, false);
+		Job job = new Job.JobBuilder(0).jobName(jobName).buildParameters(params).build();
+		String actual = job.buildUrl(server, vars, false);
+
+		String expectedQuery = "param1=" +  URLEncoder.encode("\"{\"GIT_BRANCH\":\"branchname\"}", "UTF-8");
+		assertEquals(server.getBaseUrl() + "/job/" + jobName + "/buildWithParameters?"
+				+ expectedQuery, actual);
 	}
 
 	@Test

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/GlobalResourceTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/GlobalResourceTest.java
@@ -33,7 +33,7 @@ public class GlobalResourceTest {
 
     @Before
     public void setup() throws Exception {
-        globalServer = new Server("globalurl", "global server", "globaluser", "globaltoken", false, false);
+        globalServer = new Server("http://globalurl", "global server", "globaluser", "globaltoken", false, false);
         I18nService i18nService = mock(I18nService.class);
         jenkins = mock(Jenkins.class);
         authContext = mock(AuthenticationContext.class);
@@ -147,7 +147,7 @@ public class GlobalResourceTest {
         when(jenkins.getJenkinsServer(null)).thenReturn(globalServer);
         Server testServer = rest.mapToServer(globalServer.asMap());
         testServer.setToken(null);
-        testServer.setBaseUrl("different");
+        testServer.setBaseUrl("http://different");
         rest.addServer(ui, testServer);
 
         assertEquals("", testServer.getToken());
@@ -193,6 +193,28 @@ public class GlobalResourceTest {
         List<String> errors = (List<String>) new Gson().fromJson(response, Map.class).get("errors");
 
         assertEquals(Lists.newArrayList("Base Url required."), errors);
+    }
+
+    @Test
+    public void testAddServerReturns422OnBadUrl(){
+        globalServer.setBaseUrl("noprotocal");
+        when(jenkins.getJenkinsServer(null)).thenReturn(null);
+        Response actual = rest.addServer(ui, globalServer);
+
+        assertEquals(422, actual.getStatus());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAddServerReturnsErrorMessageOnBadUrl(){
+        globalServer.setBaseUrl("noprotocal");
+        when(jenkins.getJenkinsServer(null)).thenReturn(null);
+        Response actual = rest.addServer(ui, globalServer);
+
+        String response = actual.getEntity().toString();
+        List<String> errors = (List<String>) new Gson().fromJson(response, Map.class).get("errors");
+
+        assertEquals(Lists.newArrayList("Invalide Base Url."), errors);
     }
 
     @Test

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/ProjectResourceTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/ProjectResourceTest.java
@@ -35,7 +35,7 @@ public class ProjectResourceTest {
 
     @Before
     public void setup() throws Exception {
-        projectServer = new Server("projecturl", "project server", "projectuser", "projecttoken", false, false);
+        projectServer = new Server("http://projecturl", "project server", "projectuser", "projecttoken", false, false);
         projectKey = "TEST";
         I18nService i18nService = mock(I18nService.class);
         jenkins = mock(Jenkins.class);
@@ -155,7 +155,7 @@ public class ProjectResourceTest {
         when(jenkins.getJenkinsServer(projectKey)).thenReturn(projectServer);
         Server testServer = rest.mapToServer(projectServer.asMap());
         testServer.setToken(null);
-        testServer.setBaseUrl("different");
+        testServer.setBaseUrl("http://different");
         rest.addServer(ui, testServer);
 
         assertEquals("", testServer.getToken());
@@ -201,6 +201,28 @@ public class ProjectResourceTest {
         List<String> errors = (List<String>) new Gson().fromJson(response, Map.class).get("errors");
 
         assertEquals(Lists.newArrayList("Base Url required."), errors);
+    }
+
+    @Test
+    public void testAddServerReturns422OnBadUrl(){
+        projectServer.setBaseUrl("noprotocal");
+        when(jenkins.getJenkinsServer(null)).thenReturn(null);
+        Response actual = rest.addServer(ui, projectServer);
+
+        assertEquals(422, actual.getStatus());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAddServerReturnsErrorMessageOnBadUrl(){
+        projectServer.setBaseUrl("noprotocal");
+        when(jenkins.getJenkinsServer(null)).thenReturn(null);
+        Response actual = rest.addServer(ui, projectServer);
+
+        String response = actual.getEntity().toString();
+        List<String> errors = (List<String>) new Gson().fromJson(response, Map.class).get("errors");
+
+        assertEquals(Lists.newArrayList("Invalide Base Url."), errors);
     }
 
     @Test


### PR DESCRIPTION
The current version of the plugin does not support special characters hardcoded in job build parameters as noted in #212. This is because only the values of the bitbucket variables are encoded properly.

This PR changes the building of the url to use `org.apache.http.client.utils.URIBuilder` instead of `javax.ws.rs.core.UriBuilder`. The new URIBuilder automatically encodes all query params for us where the old UriBuilder would inconsistently encode some values but not others. I also added additional validation on server base urls to ensure some of the new behaviors of URIBuilder do not cause build errors.