### PR TITLE
Use url context from base url

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/item/Job.java
@@ -14,6 +14,8 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.collect.Lists;
+
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -314,7 +316,8 @@ public class Job {
         }
         hasParameters = !isPipeline || !trigger.isRefChange() ? hasParameters : false;
 
-        List<String> pathSegments = new ArrayList<>();
+        // builder.getPathSegments is an immutable list so we need to use a new list
+        List<String> pathSegments =  Lists.newArrayList(builder.getPathSegments());
 
         if (useUserToken || !jenkinsServer.getAltUrl()) {
             pathSegments.add("job");

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/JenkinsTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/ciserver/JenkinsTest.java
@@ -284,6 +284,26 @@ public class JenkinsTest {
     }
 
     @Test
+    public void testTriggerJobWithServerContext(){
+        String userToken = USER_SLUG + ":token";
+        String userCSRF = null;
+        Server expected = new Server("http://globalurl/jenkins", null, user.getDisplayName(), "token", false, false);
+        when(pluginSettings.get(".jenkinsSettings." + PROJECT_KEY)).thenReturn(expected.asMap());
+        when(pluginSettings.get(".jenkinsUser." + USER_SLUG + "." + PROJECT_KEY))
+                .thenReturn("token");
+
+        Job job = new Job.JobBuilder(1).jobName("testJob").buildParameters("").branchRegex("")
+                .jenkinsServer(PROJECT_KEY).pathRegex("").prDestRegex("").build();
+        BitbucketVariables bitbucketVariables = new BitbucketVariables.Builder()
+                .add("$TRIGGER", () -> Job.Trigger.ADD.toString())
+                .build();
+        Jenkins jenkinsSpy = spy(jenkins);
+        jenkinsSpy.triggerJob(PROJECT_KEY, user, job, bitbucketVariables);
+
+        verify(jenkinsSpy, times(1)).sanitizeTrigger("http://globalurl/jenkins/job/testJob/build", userToken, userCSRF, false);
+    }
+
+    @Test
     public void testTriggerJobUseJobServerGlobal(){
         String userToken = USER_SLUG + ":token";
         String userCSRF = null;


### PR DESCRIPTION
Solves #221. Since the new UriBuilder overrides the path segments provided, we need to start with a list of path segments from the base url.