### PR TITLE
Downgrade http-client to fix runtime errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kylenicholls.stash</groupId>
     <artifactId>parameterized-builds</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.7</version>
 
     <organization>
         <name>Kyle Nicholls</name>
@@ -178,7 +178,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.9</version>
+            <version>4.5.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
I'm getting a lot of issues running new versions of the plugin because of Bitbucket sometimes complaining about "setPathSegments" method not found. It seems like there's some sort of race condition happening that causes Bitbucket to sometimes use an old version of httpclient? Either way, reverting to an earlier version seems to make things more consistent.