### PR TITLE
[#219] Test Jenkins settings with token

### DIFF
--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/GlobalResource.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/GlobalResource.java
@@ -66,6 +66,9 @@ public class GlobalResource extends RestResource implements ServerService{
     @Produces({ RestUtils.APPLICATION_JSON_UTF8 })
     public Response validate(@Context UriInfo ui, Server server){
         if (authContext.isAuthenticated()) {
+            Server oldServer = jenkins.getJenkinsServer(null);
+            server.setToken(getCurrentDefaultToken(oldServer, server));
+
             String message = jenkins.testConnection(server);
 
             if(message.equals("Connection successful")){
@@ -95,17 +98,7 @@ public class GlobalResource extends RestResource implements ServerService{
             }
 
             Server oldServer = jenkins.getJenkinsServer(null);
-            // if the new server didn't edit the token attribute and the server
-            // credentials should be the same, save the old token
-            if (oldServer != null &&
-                    server.getToken() == null &&
-                    oldServer.getBaseUrl() == server.getBaseUrl() &&
-                    oldServer.getUser() == server.getUser()) {
-                server.setToken(oldServer.getToken());
-            }
-            if (server.getToken() == null){
-                server.setToken("");
-            }
+            server.setToken(getCurrentDefaultToken(oldServer, server));
 
             int returnStatus = oldServer == null ? 201 : 200;
             jenkins.saveJenkinsServer(server, null);

--- a/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/ServerService.java
+++ b/src/main/java/com/kylenicholls/stash/parameterizedbuilds/rest/ServerService.java
@@ -86,4 +86,24 @@ public interface ServerService {
         return new Server(serverMap);
     }
 
+    default String getCurrentDefaultToken(Server oldServer, Server newServer){
+        // if the new server didn't edit the token attribute and the server
+        // credentials should be the same, save the old token
+        if (shouldUseOldToken(oldServer, newServer)) {
+            return oldServer.getToken();
+        } else if (newServer.getToken() == null) {
+            return "";
+        } else {
+            return newServer.getToken();
+        }
+    }
+
+    default boolean shouldUseOldToken(Server oldServer, Server newServer){
+        return
+            oldServer != null &&
+            newServer.getToken() == null &&
+            oldServer.getBaseUrl().equals(newServer.getBaseUrl()) &&
+            oldServer.getUser().equals(newServer.getUser());
+    }
+
 }

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/GlobalResourceTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/GlobalResourceTest.java
@@ -1,6 +1,7 @@
 package com.kylenicholls.stash.parameterizedbuilds.rest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -105,6 +106,18 @@ public class GlobalResourceTest {
         Response actual = rest.validate(ui, globalServer);
 
         assertEquals(400, actual.getStatus());
+    }
+
+    @Test
+    public void testValidateServerPreservesToken(){
+        when(jenkins.getJenkinsServer(null)).thenReturn(globalServer);
+        Server testServer = rest.mapToServer(globalServer.asMap());
+        when(jenkins.testConnection(testServer)).thenReturn( "Connection successful");
+        testServer.setToken(null);
+        rest.validate(ui, testServer);
+
+        assertEquals(globalServer.getToken(), testServer.getToken());
+        assertNotNull(testServer.getToken());
     }
 
     @Test

--- a/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/ProjectResourceTest.java
+++ b/src/test/java/com/kylenicholls/stash/parameterizedbuilds/rest/ProjectResourceTest.java
@@ -1,6 +1,7 @@
 package com.kylenicholls.stash.parameterizedbuilds.rest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -113,6 +114,18 @@ public class ProjectResourceTest {
         Response actual = rest.validate(ui, projectServer);
 
         assertEquals(400, actual.getStatus());
+    }
+
+    @Test
+    public void testValidateServerPreservesToken(){
+        when(jenkins.getJenkinsServer(projectKey)).thenReturn(projectServer);
+        Server testServer = rest.mapToServer(projectServer.asMap());
+        when(jenkins.testConnection(testServer)).thenReturn( "Connection successful");
+        testServer.setToken(null);
+        rest.validate(ui, testServer);
+
+        assertEquals(projectServer.getToken(), testServer.getToken());
+        assertNotNull(testServer.getToken());
     }
 
     @Test


### PR DESCRIPTION
Currently, jenkins settings validation happens without the currently set token. I figured that it would make more sense that way because you could test what was currently on the page. However, this does cause a divergence in behavior between what happens on save and test. Since the current ui around the token is a little confusing, it just causes confusion about what is going on under the hood (see #219).

This PR aims to create validation like saving. That should at least resolve some of the confusion around token handling. The UI still needs to be updated to be clearer though.